### PR TITLE
Fix lighting distribution in national project

### DIFF
--- a/project_resstock_national/housing_characteristics/Lighting.tsv
+++ b/project_resstock_national/housing_characteristics/Lighting.tsv
@@ -1,2 +1,2 @@
 Option=100% Incandescent	Option=60% CFL	Option=100% CFL
-0.87	0.07	0.06
+0.433	0.074	0.493


### PR DESCRIPTION
Old numbers were caused by misinterpretation of RECS data and were corrected in post-processing for the QER analysis. This PR updates the distributions to the correct RECS 2009 distributions.