### PR TITLE
TSV Speed Improvements

### DIFF
--- a/resources/run_sampling.rb
+++ b/resources/run_sampling.rb
@@ -156,20 +156,15 @@ class RunSampling
     if dep_hash.nil?
       return tsvfile.rows[0]
     end
-
-    tsvfile.rows.each_with_index do |tsvrow, index|
-      row_matched = true
-      tsvfile.dependency_cols.each do |dep_name, dep_col|
-        next if tsvrow[dep_col] == dep_hash[dep_name]
-
-        row_matched = false
-        break
-      end
-      if row_matched
-        return tsvrow
-      end
+    
+    key_s_downcase = hash_to_string(dep_hash).downcase
+    rownum = tsvfile.rows_keys_s.index(key_s_downcase)
+    
+    if rownum.nil?
+      register_error("Could not find row in #{tsvfile.filename} with dependency values: #{dep_hash.to_s}.", nil)
     end
-    register_error("Could not find row in #{tsvfile.filename} with dependency values: #{dep_hash.to_s}.", nil)
+
+    return tsvfile.rows[rownum]
   end
 
   def binary_search(arr, value)


### PR DESCRIPTION
This PR substantially speeds up integrity checks for TSVs with large numbers of rows (and has the side benefit of speeding up sampling) by using caching.

Results for the multifamily project:

Scenario | Before [sec] | After [sec] | Savings
-- | -- | -- | --
Rake integrity check | 1133 | 110 | 90%
10k sampling | 454 | 363 | 20%

I verified that the sampling results are unchanged and that the integrity checks still catch the variety of errors that could be in the TSVs. 

@joseph-robertson any chance you could do a quick test run to make sure simulations don't somehow break?