### PR TITLE
Integrity check changes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -329,7 +329,7 @@ def integrity_check_options_lookup_tsv(project_dir_name)
     param_names = measures[measure_subdir].keys()
     options_array = []
     param_names.each do |parameter_name|
-      if ["Bathroom Spot Vent Hour", "Clothes Dryer Spot Vent Hour", "Range Spot Vent Hour"].include? parameter_name
+      if ["Bathroom Spot Vent Hour", "Range Spot Vent Hour"].include? parameter_name
         # Prevent "too big to product" error for airflow measure by just
         # using first option for these parameters.
         options_array << [measures[measure_subdir][parameter_name].keys()[0]]

--- a/Rakefile
+++ b/Rakefile
@@ -288,7 +288,7 @@ def integrity_check_options_lookup_tsv(project_dir_name)
     tsvpath = File.join(project_dir_name, "housing_characteristics", "#{parameter_name}.tsv")
     next if not File.exist?(tsvpath) # Not every parameter used by every project
 
-    option_names = get_options_for_parameter_from_options_lookup_tsv(resources_dir, parameter_name)
+    option_names = get_options_for_parameter_from_tsv_file(project_dir_name, parameter_name)
     options_measure_args = get_measure_args_from_option_names(lookup_file, option_names, parameter_name, nil)
     option_names.each do |option_name|
       # Check for (parameter, option) names
@@ -316,6 +316,12 @@ def integrity_check_options_lookup_tsv(project_dir_name)
       end
     end
   end
+
+  bldg_data = {}
+  if project_dir_name.include? "national"
+    bldg_data["Geometry Building Type"] = "Single-Family Detached"
+  end
+  hack_to_run_the_correct_resstock_geometry_measure(measures, bldg_data) # FIXME
 
   max_checks = 1000
   measures.keys.each do |measure_subdir|

--- a/measures/BuildExistingModel/measure.rb
+++ b/measures/BuildExistingModel/measure.rb
@@ -133,17 +133,7 @@ class BuildExistingModel < OpenStudio::Measure::ModelMeasure
       end
     end
 
-    # FIXME: Hack to run the correct ResStock geometry measure
-    if ["Single-Family Detached", "Mobile Home"].include? bldg_data["Geometry Building Type"]
-      measures.delete("ResidentialGeometryCreateSingleFamilyAttached")
-      measures.delete("ResidentialGeometryCreateMultifamily")
-    elsif bldg_data["Geometry Building Type"] == "Single-Family Attached"
-      measures.delete("ResidentialGeometryCreateSingleFamilyDetached")
-      measures.delete("ResidentialGeometryCreateMultifamily")
-    elsif ["Multi-Family with 2 - 4 Units", "Multi-Family with 5+ Units"].include? bldg_data["Geometry Building Type"]
-      measures.delete("ResidentialGeometryCreateSingleFamilyDetached")
-      measures.delete("ResidentialGeometryCreateSingleFamilyAttached")
-    end
+    hack_to_run_the_correct_resstock_geometry_measure(measures, bldg_data) # FIXME
 
     if not apply_measures(measures_dir, measures, runner, model, workflow_json, "measures.osw", true)
       return false

--- a/project_resstock_national/housing_characteristics/Geometry Building Type.tsv
+++ b/project_resstock_national/housing_characteristics/Geometry Building Type.tsv
@@ -1,11 +1,2 @@
-Dependency=Location Region	Option=Mobile Home	Option=Multi-Family with 2 - 4 Units	Option=Multi-Family with 5+ Units	Option=Single-Family Attached	Option=Single-Family Detached	Count	Weight
-CR10	0	0	0	0	1	367	3984684
-CR11	0	0	0	0	1	1606	12214891
-CR02	0	0	0	0	1	941	6180497
-CR03	0	0	0	0	1	938	5511097
-CR04	0	0	0	0	1	908	15581140
-CR05	0	0	0	0	1	445	3920592
-CR06	0	0	0	0	1	466	4727940
-CR07	0	0	0	0	1	1328	15259350
-CR08	0	0	0	0	1	1752	12994609
-CR09	0	0	0	0	1	3332	33241429
+Option=Single-Family Detached
+1

--- a/project_resstock_national/housing_characteristics/Geometry Is Multifamily Low Rise.tsv
+++ b/project_resstock_national/housing_characteristics/Geometry Is Multifamily Low Rise.tsv
@@ -1,6 +1,2 @@
-Dependency=Geometry Building Type	Option=True	Option=False
-Mobile Home	0	1
-Multi-Family with 2 - 4 Units	1	0
-Multi-Family with 5+ Units	1	0
-Single-Family Attached	1	0
-Single-Family Detached	0	1
+Option=False
+1


### PR DESCRIPTION
@afontani ran into an issue where the integrity check for his custom project failed due to memory error (specifically on this line: https://github.com/NREL/OpenStudio-BuildStock/blob/master/Rakefile#L340).

We believe this happens because that line is trying to take the product of ALL options in the options lookup, instead of just those options found in the project you are running the integrity check against.

@shorowit 

