### PR TITLE
Register climate zones

### DIFF
--- a/measures/BuildingCharacteristicsReport/measure.rb
+++ b/measures/BuildingCharacteristicsReport/measure.rb
@@ -35,6 +35,8 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       "location_state",
       "location_latitude",
       "location_longitude",
+      "climate_zone_ba",
+      "climate_zone_iecc",
       "units_represented",
       "units_modeled"
     ]
@@ -104,6 +106,10 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       runner.registerValue("location_latitude", weather.header.Latitude)
       runner.registerInfo("Registering #{weather.header.Longitude} for location_longitude.")
       runner.registerValue("location_longitude", weather.header.Longitude)
+      runner.registerInfo("Registering #{Location.get_climate_zone_ba(weather.header.Station)} for climate_zone_ba.")
+      runner.registerValue("climate_zone_ba", Location.get_climate_zone_ba(weather.header.Station))
+      runner.registerInfo("Registering #{Location.get_climate_zone_iecc(weather.header.Station)} for climate_zone_iecc.")
+      runner.registerValue("climate_zone_iecc", Location.get_climate_zone_iecc(weather.header.Station))
     end
 
     units_represented = model.getBuilding.additionalProperties.getFeatureAsInteger("Total Units Represented")

--- a/measures/BuildingCharacteristicsReport/measure.xml
+++ b/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>5f3e6eca-2956-4387-9a46-eb44da9cf6a8</version_id>
-  <version_modified>20190419T174258Z</version_modified>
+  <version_id>7469cd9d-9af3-4d66-a843-28fab13a1e67</version_id>
+  <version_modified>20190430T212135Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -726,6 +726,20 @@
       <model_dependent>false</model_dependent>
     </output>
     <output>
+      <name>climate_zone_ba</name>
+      <display_name>climate_zone_ba</display_name>
+      <short_name>climate_zone_ba</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>climate_zone_iecc</name>
+      <display_name>climate_zone_iecc</display_name>
+      <short_name>climate_zone_iecc</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
       <name>units_represented</name>
       <display_name>units_represented</display_name>
       <short_name>units_represented</short_name>
@@ -766,7 +780,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>80C0B14F</checksum>
+      <checksum>83A9FA0B</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/measures/BuildingCharacteristicsReport/measure.rb
+++ b/project_multifamily_beta/measures/BuildingCharacteristicsReport/measure.rb
@@ -35,6 +35,8 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       "location_state",
       "location_latitude",
       "location_longitude",
+      "climate_zone_ba",
+      "climate_zone_iecc",
       "units_represented",
       "units_modeled"
     ]
@@ -104,6 +106,10 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       runner.registerValue("location_latitude", weather.header.Latitude)
       runner.registerInfo("Registering #{weather.header.Longitude} for location_longitude.")
       runner.registerValue("location_longitude", weather.header.Longitude)
+      runner.registerInfo("Registering #{Location.get_climate_zone_ba(weather.header.Station)} for climate_zone_ba.")
+      runner.registerValue("climate_zone_ba", Location.get_climate_zone_ba(weather.header.Station))
+      runner.registerInfo("Registering #{Location.get_climate_zone_iecc(weather.header.Station)} for climate_zone_iecc.")
+      runner.registerValue("climate_zone_iecc", Location.get_climate_zone_iecc(weather.header.Station))
     end
 
     units_represented = model.getBuilding.additionalProperties.getFeatureAsInteger("Total Units Represented")

--- a/project_multifamily_beta/measures/BuildingCharacteristicsReport/measure.xml
+++ b/project_multifamily_beta/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>5f3e6eca-2956-4387-9a46-eb44da9cf6a8</version_id>
-  <version_modified>20190419T174258Z</version_modified>
+  <version_id>7469cd9d-9af3-4d66-a843-28fab13a1e67</version_id>
+  <version_modified>20190430T212135Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -726,6 +726,20 @@
       <model_dependent>false</model_dependent>
     </output>
     <output>
+      <name>climate_zone_ba</name>
+      <display_name>climate_zone_ba</display_name>
+      <short_name>climate_zone_ba</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>climate_zone_iecc</name>
+      <display_name>climate_zone_iecc</display_name>
+      <short_name>climate_zone_iecc</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
       <name>units_represented</name>
       <display_name>units_represented</display_name>
       <short_name>units_represented</short_name>
@@ -766,7 +780,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>80C0B14F</checksum>
+      <checksum>83A9FA0B</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/pat.json
+++ b/project_multifamily_beta/pat.json
@@ -288,15 +288,15 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.28682554806897365,
+      "instanceId": 0.1539452810671036,
       "skip": false,
       "$$hashKey": "object:7717",
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildExistingModel",
       "name": "build_existing_model",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildExistingModel",
       "uid": "dedf59bb-3b88-4f16-8755-2c1ff5519cbf",
       "uuid": "{dedf59bb-3b88-4f16-8755-2c1ff5519cbf}",
       "version_id": "dcc77832-f110-4de8-a3c0-41b134c2a9a8",
@@ -447,16 +447,16 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.8406354705020691,
+      "instanceId": 0.5660089163608848,
       "skip": false,
       "$$hashKey": "object:34492",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\ApplyUpgrade",
       "name": "apply_upgrade",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\ApplyUpgrade",
       "uid": "33f1654c-f734-43d1-b35d-9d2856e41b5a",
       "uuid": "{33f1654c-f734-43d1-b35d-9d2856e41b5a}",
       "version_id": "9136d68f-bbdf-4548-993e-8912202b76ed",
@@ -3279,16 +3279,16 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.6234903088964743,
+      "instanceId": 0.5414099570596453,
       "skip": false,
       "$$hashKey": "object:31044",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\ApplyUpgrade",
       "name": "apply_upgrade_2",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\ApplyUpgrade",
       "uid": "33f1654c-f734-43d1-b35d-9d2856e41b5a",
       "uuid": "{33f1654c-f734-43d1-b35d-9d2856e41b5a}",
       "version_id": "9136d68f-bbdf-4548-993e-8912202b76ed",
@@ -6111,7 +6111,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.9291136962357369,
+      "instanceId": 0.7356199366467449,
       "skip": false,
       "showWarningText": false,
       "$$hashKey": "object:33811",
@@ -6123,9 +6123,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
-      "version_id": "5f3e6eca-2956-4387-9a46-eb44da9cf6a8",
-      "version_uuid": "{5f3e6eca-2956-4387-9a46-eb44da9cf6a8}",
-      "version_modified": "20190419T174258Z",
+      "version_id": "7469cd9d-9af3-4d66-a843-28fab13a1e67",
+      "version_uuid": "{7469cd9d-9af3-4d66-a843-28fab13a1e67}",
+      "version_modified": "20190430T212135Z",
       "xml_checksum": "2EA103AF",
       "display_name": "Building Characteristics Report",
       "class_name": "BuildingCharacteristicsReport",
@@ -6140,7 +6140,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11510"
         },
         {
           "name": "location_heating_region",
@@ -6149,7 +6150,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11511"
         },
         {
           "name": "location_cooling_region",
@@ -6158,7 +6160,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11512"
         },
         {
           "name": "location",
@@ -6167,7 +6170,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11513"
         },
         {
           "name": "location_weather_filename",
@@ -6176,7 +6180,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11514"
         },
         {
           "name": "location_weather_year",
@@ -6185,7 +6190,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11515"
         },
         {
           "name": "vintage",
@@ -6194,7 +6200,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11516"
         },
         {
           "name": "vintage_fpl",
@@ -6203,7 +6210,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11517"
         },
         {
           "name": "heating_fuel",
@@ -6212,7 +6220,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11518"
         },
         {
           "name": "usage_level",
@@ -6221,7 +6230,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11519"
         },
         {
           "name": "geometry_building_type",
@@ -6230,7 +6240,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11520"
         },
         {
           "name": "geometry_building_type_fpl",
@@ -6239,7 +6250,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11521"
         },
         {
           "name": "geometry_number_units",
@@ -6248,7 +6260,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11522"
         },
         {
           "name": "geometry_building_number_units_mf",
@@ -6257,7 +6270,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11523"
         },
         {
           "name": "geometry_building_number_units_sfa",
@@ -6266,7 +6280,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11524"
         },
         {
           "name": "geometry_building_number_units_hl",
@@ -6275,7 +6290,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11525"
         },
         {
           "name": "geometry_foundation_type",
@@ -6284,7 +6300,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11526"
         },
         {
           "name": "geometry_heated_basement",
@@ -6293,7 +6310,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11527"
         },
         {
           "name": "geometry_stories",
@@ -6302,7 +6320,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11528"
         },
         {
           "name": "geometry_building_floors",
@@ -6311,7 +6330,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11529"
         },
         {
           "name": "geometry_garage",
@@ -6320,7 +6340,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11530"
         },
         {
           "name": "geometry_house_size",
@@ -6329,7 +6350,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11531"
         },
         {
           "name": "geometry_shared_walls",
@@ -6338,7 +6360,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11532"
         },
         {
           "name": "geometry_shared_walls_sfa",
@@ -6347,7 +6370,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11533"
         },
         {
           "name": "geometry_shared_walls_mf",
@@ -6356,7 +6380,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11534"
         },
         {
           "name": "geometry_number_units_acs_bins",
@@ -6365,7 +6390,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11535"
         },
         {
           "name": "geometry_unit_stories_sf",
@@ -6374,7 +6400,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11536"
         },
         {
           "name": "geometry_unit_stories_mf",
@@ -6383,7 +6410,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11537"
         },
         {
           "name": "geometry_is_multifamily_low_rise",
@@ -6392,7 +6420,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11538"
         },
         {
           "name": "occupants",
@@ -6401,7 +6430,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11539"
         },
         {
           "name": "orientation",
@@ -6410,7 +6440,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11540"
         },
         {
           "name": "eaves",
@@ -6419,7 +6450,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11541"
         },
         {
           "name": "door_area",
@@ -6428,7 +6460,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11542"
         },
         {
           "name": "window_areas",
@@ -6437,7 +6470,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11543"
         },
         {
           "name": "overhangs",
@@ -6446,7 +6480,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11544"
         },
         {
           "name": "neighbors",
@@ -6455,7 +6490,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11545"
         },
         {
           "name": "insulation_unfinished_attic",
@@ -6464,7 +6500,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11546"
         },
         {
           "name": "insulation_finished_roof",
@@ -6473,7 +6510,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11547"
         },
         {
           "name": "roof_material",
@@ -6482,7 +6520,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11548"
         },
         {
           "name": "insulation_slab",
@@ -6491,7 +6530,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11549"
         },
         {
           "name": "insulation_crawlspace",
@@ -6500,7 +6540,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11550"
         },
         {
           "name": "insulation_unfinished_basement",
@@ -6509,7 +6550,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11551"
         },
         {
           "name": "insulation_finished_basement",
@@ -6518,7 +6560,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11552"
         },
         {
           "name": "insulation_pier_beam",
@@ -6527,7 +6570,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11553"
         },
         {
           "name": "insulation_interzonal_floor",
@@ -6536,7 +6580,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11554"
         },
         {
           "name": "insulation_wall",
@@ -6545,7 +6590,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11555"
         },
         {
           "name": "windows",
@@ -6554,7 +6600,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11556"
         },
         {
           "name": "doors",
@@ -6563,7 +6610,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11557"
         },
         {
           "name": "water_heater",
@@ -6572,7 +6620,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11558"
         },
         {
           "name": "hot_water_fixtures",
@@ -6581,7 +6630,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11559"
         },
         {
           "name": "hot_water_distribution",
@@ -6590,7 +6640,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11560"
         },
         {
           "name": "solar_hot_water",
@@ -6599,7 +6650,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11561"
         },
         {
           "name": "hvac_system_is_shared",
@@ -6608,7 +6660,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11562"
         },
         {
           "name": "hvac_system_shared_electricity",
@@ -6617,7 +6670,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11563"
         },
         {
           "name": "hvac_system_shared_natural_gas",
@@ -6626,7 +6680,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11564"
         },
         {
           "name": "hvac_system_shared_propane",
@@ -6635,7 +6690,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11565"
         },
         {
           "name": "hvac_system_shared_fuel_oil",
@@ -6644,7 +6700,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11566"
         },
         {
           "name": "hvac_system_shared_other_fuel",
@@ -6653,7 +6710,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11567"
         },
         {
           "name": "hvac_system_shared_none",
@@ -6662,7 +6720,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11568"
         },
         {
           "name": "hvac_system_is_heat_pump",
@@ -6671,7 +6730,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11569"
         },
         {
           "name": "hvac_system_heat_pump",
@@ -6680,7 +6740,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11570"
         },
         {
           "name": "hvac_system_heating_electricity",
@@ -6689,7 +6750,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11571"
         },
         {
           "name": "hvac_system_heating_natural_gas",
@@ -6698,7 +6760,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11572"
         },
         {
           "name": "hvac_system_heating_propane",
@@ -6707,7 +6770,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11573"
         },
         {
           "name": "hvac_system_heating_fuel_oil",
@@ -6716,7 +6780,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11574"
         },
         {
           "name": "hvac_system_heating_wood",
@@ -6725,7 +6790,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11575"
         },
         {
           "name": "hvac_system_heating_other_fuel",
@@ -6734,7 +6800,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11576"
         },
         {
           "name": "hvac_system_heating_none",
@@ -6743,7 +6810,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11577"
         },
         {
           "name": "hvac_system_cooling",
@@ -6752,7 +6820,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11578"
         },
         {
           "name": "hvac_system_cooling_type",
@@ -6761,7 +6830,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11579"
         },
         {
           "name": "heating_setpoint",
@@ -6770,7 +6840,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11580"
         },
         {
           "name": "cooling_setpoint",
@@ -6779,7 +6850,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11581"
         },
         {
           "name": "ceiling_fan",
@@ -6788,7 +6860,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11582"
         },
         {
           "name": "dehumidifier",
@@ -6797,7 +6870,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11583"
         },
         {
           "name": "refrigerator",
@@ -6806,7 +6880,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11584"
         },
         {
           "name": "cooking_range",
@@ -6815,7 +6890,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11585"
         },
         {
           "name": "dishwasher",
@@ -6824,7 +6900,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11586"
         },
         {
           "name": "clothes_washer",
@@ -6833,7 +6910,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11587"
         },
         {
           "name": "clothes_dryer",
@@ -6842,7 +6920,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11588"
         },
         {
           "name": "lighting",
@@ -6851,7 +6930,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11589"
         },
         {
           "name": "plug_loads",
@@ -6860,7 +6940,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11590"
         },
         {
           "name": "misc_extra_refrigerator",
@@ -6869,7 +6950,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11591"
         },
         {
           "name": "misc_freezer",
@@ -6878,7 +6960,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11592"
         },
         {
           "name": "misc_gas_fireplace",
@@ -6887,7 +6970,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11593"
         },
         {
           "name": "misc_gas_grill",
@@ -6896,7 +6980,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11594"
         },
         {
           "name": "misc_gas_lighting",
@@ -6905,7 +6990,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11595"
         },
         {
           "name": "misc_hot_tub_spa",
@@ -6914,7 +7000,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11596"
         },
         {
           "name": "misc_pool",
@@ -6923,7 +7010,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11597"
         },
         {
           "name": "misc_well_pump",
@@ -6932,7 +7020,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11598"
         },
         {
           "name": "ducts",
@@ -6941,7 +7030,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11599"
         },
         {
           "name": "infiltration",
@@ -6950,7 +7040,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11600"
         },
         {
           "name": "natural_ventilation",
@@ -6959,7 +7050,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11601"
         },
         {
           "name": "mechanical_ventilation",
@@ -6968,7 +7060,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11602"
         },
         {
           "name": "bathroom_spot_vent_hour",
@@ -6977,7 +7070,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11603"
         },
         {
           "name": "range_spot_vent_hour",
@@ -6986,7 +7080,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11604"
         },
         {
           "name": "pv",
@@ -6995,7 +7090,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11605"
         },
         {
           "name": "days_shifted",
@@ -7004,7 +7100,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11606"
         },
         {
           "name": "geometry_perimeter_footprint_ratio",
@@ -7013,7 +7110,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11607"
         },
         {
           "name": "location_city",
@@ -7022,7 +7120,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11608"
         },
         {
           "name": "location_state",
@@ -7031,7 +7130,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11609"
         },
         {
           "name": "location_latitude",
@@ -7040,7 +7140,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11610"
         },
         {
           "name": "location_longitude",
@@ -7049,7 +7150,30 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11611"
+        },
+        {
+          "name": "climate_zone_ba",
+          "display_name": "climate_zone_ba",
+          "short_name": "climate_zone_ba",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:11612",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "climate_zone_iecc",
+          "display_name": "climate_zone_iecc",
+          "short_name": "climate_zone_iecc",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:11613",
+          "checked": true,
+          "visualize": "true"
         },
         {
           "name": "units_represented",
@@ -7058,7 +7182,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11614"
         },
         {
           "name": "units_modeled",
@@ -7067,7 +7192,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:11615"
         }
       ],
       "attributes": [
@@ -7090,13 +7216,13 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "4/19/2019",
+      "date": "4/30/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.009358571435191587,
+      "instanceId": 0.29536305718480826,
       "skip": false,
       "$$hashKey": "object:15756",
       "outputMeasure": true,
@@ -8245,6 +8371,28 @@
           "$$hashKey": "object:16307",
           "checked": true,
           "visualize": "true"
+        },
+        {
+          "name": "climate_zone_ba",
+          "display_name": "climate_zone_ba",
+          "short_name": "climate_zone_ba",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:11612",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "climate_zone_iecc",
+          "display_name": "climate_zone_iecc",
+          "short_name": "climate_zone_iecc",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:11613",
+          "checked": true,
+          "visualize": "true"
         }
       ]
     },
@@ -8973,7 +9121,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.4148976319035673,
+      "instanceId": 0.6732630897928553,
       "skip": false,
       "$$hashKey": "object:15757",
       "outputMeasure": true,
@@ -9792,7 +9940,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.8791368522393013,
+      "instanceId": 0.7209667009210183,
       "skip": false,
       "$$hashKey": "object:15758",
       "outputMeasure": false
@@ -9839,7 +9987,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.2608060494733446,
+      "instanceId": 0.9294687036637432,
       "skip": false,
       "$$hashKey": "object:663249",
       "outputMeasure": false
@@ -9883,6 +10031,6 @@
     }
   },
   "designAlternatives": [],
-  "analysisID": null,
+  "analysisID": "",
   "datapoints": []
 }

--- a/project_singlefamilydetached/measures/BuildingCharacteristicsReport/measure.rb
+++ b/project_singlefamilydetached/measures/BuildingCharacteristicsReport/measure.rb
@@ -35,6 +35,8 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       "location_state",
       "location_latitude",
       "location_longitude",
+      "climate_zone_ba",
+      "climate_zone_iecc",
       "units_represented",
       "units_modeled"
     ]
@@ -104,6 +106,10 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       runner.registerValue("location_latitude", weather.header.Latitude)
       runner.registerInfo("Registering #{weather.header.Longitude} for location_longitude.")
       runner.registerValue("location_longitude", weather.header.Longitude)
+      runner.registerInfo("Registering #{Location.get_climate_zone_ba(weather.header.Station)} for climate_zone_ba.")
+      runner.registerValue("climate_zone_ba", Location.get_climate_zone_ba(weather.header.Station))
+      runner.registerInfo("Registering #{Location.get_climate_zone_iecc(weather.header.Station)} for climate_zone_iecc.")
+      runner.registerValue("climate_zone_iecc", Location.get_climate_zone_iecc(weather.header.Station))
     end
 
     units_represented = model.getBuilding.additionalProperties.getFeatureAsInteger("Total Units Represented")

--- a/project_singlefamilydetached/measures/BuildingCharacteristicsReport/measure.xml
+++ b/project_singlefamilydetached/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>5f3e6eca-2956-4387-9a46-eb44da9cf6a8</version_id>
-  <version_modified>20190419T174258Z</version_modified>
+  <version_id>7469cd9d-9af3-4d66-a843-28fab13a1e67</version_id>
+  <version_modified>20190430T212135Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -726,6 +726,20 @@
       <model_dependent>false</model_dependent>
     </output>
     <output>
+      <name>climate_zone_ba</name>
+      <display_name>climate_zone_ba</display_name>
+      <short_name>climate_zone_ba</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>climate_zone_iecc</name>
+      <display_name>climate_zone_iecc</display_name>
+      <short_name>climate_zone_iecc</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
       <name>units_represented</name>
       <display_name>units_represented</display_name>
       <short_name>units_represented</short_name>
@@ -766,7 +780,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>80C0B14F</checksum>
+      <checksum>83A9FA0B</checksum>
     </file>
   </files>
 </measure>

--- a/project_singlefamilydetached/pat.json
+++ b/project_singlefamilydetached/pat.json
@@ -288,15 +288,15 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.8527573391385286,
+      "instanceId": 0.93241874876278,
       "skip": false,
       "$$hashKey": "object:6848",
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildExistingModel",
       "name": "build_existing_model",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildExistingModel",
       "uid": "dedf59bb-3b88-4f16-8755-2c1ff5519cbf",
       "uuid": "{dedf59bb-3b88-4f16-8755-2c1ff5519cbf}",
       "version_id": "dcc77832-f110-4de8-a3c0-41b134c2a9a8",
@@ -447,16 +447,16 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.07130380797038693,
+      "instanceId": 0.5491739189721401,
       "skip": false,
       "$$hashKey": "object:34492",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\ApplyUpgrade",
       "name": "apply_upgrade",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\ApplyUpgrade",
       "uid": "33f1654c-f734-43d1-b35d-9d2856e41b5a",
       "uuid": "{33f1654c-f734-43d1-b35d-9d2856e41b5a}",
       "version_id": "9136d68f-bbdf-4548-993e-8912202b76ed",
@@ -3279,16 +3279,16 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.1373888192217383,
+      "instanceId": 0.24506501647087875,
       "skip": false,
       "$$hashKey": "object:31044",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\ApplyUpgrade",
       "name": "apply_upgrade_2",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\ApplyUpgrade",
       "uid": "33f1654c-f734-43d1-b35d-9d2856e41b5a",
       "uuid": "{33f1654c-f734-43d1-b35d-9d2856e41b5a}",
       "version_id": "9136d68f-bbdf-4548-993e-8912202b76ed",
@@ -6111,7 +6111,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.17994464625268947,
+      "instanceId": 0.7390459679712416,
       "skip": false,
       "showWarningText": false,
       "$$hashKey": "object:33811",
@@ -6123,9 +6123,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
-      "version_id": "5f3e6eca-2956-4387-9a46-eb44da9cf6a8",
-      "version_uuid": "{5f3e6eca-2956-4387-9a46-eb44da9cf6a8}",
-      "version_modified": "20190419T174258Z",
+      "version_id": "7469cd9d-9af3-4d66-a843-28fab13a1e67",
+      "version_uuid": "{7469cd9d-9af3-4d66-a843-28fab13a1e67}",
+      "version_modified": "20190430T212135Z",
       "xml_checksum": "2EA103AF",
       "display_name": "Building Characteristics Report",
       "class_name": "BuildingCharacteristicsReport",
@@ -6140,7 +6140,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10592"
         },
         {
           "name": "location_heating_region",
@@ -6149,7 +6150,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10593"
         },
         {
           "name": "location_cooling_region",
@@ -6158,7 +6160,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10594"
         },
         {
           "name": "location",
@@ -6167,7 +6170,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10595"
         },
         {
           "name": "location_weather_filename",
@@ -6176,7 +6180,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10596"
         },
         {
           "name": "location_weather_year",
@@ -6185,7 +6190,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10597"
         },
         {
           "name": "vintage",
@@ -6194,7 +6200,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10598"
         },
         {
           "name": "vintage_fpl",
@@ -6203,7 +6210,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10599"
         },
         {
           "name": "heating_fuel",
@@ -6212,7 +6220,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10600"
         },
         {
           "name": "usage_level",
@@ -6221,7 +6230,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10601"
         },
         {
           "name": "geometry_building_type",
@@ -6230,7 +6240,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10602"
         },
         {
           "name": "geometry_building_type_fpl",
@@ -6239,7 +6250,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10603"
         },
         {
           "name": "geometry_number_units",
@@ -6248,7 +6260,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10604"
         },
         {
           "name": "geometry_building_number_units_mf",
@@ -6257,7 +6270,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10605"
         },
         {
           "name": "geometry_building_number_units_sfa",
@@ -6266,7 +6280,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10606"
         },
         {
           "name": "geometry_building_number_units_hl",
@@ -6275,7 +6290,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10607"
         },
         {
           "name": "geometry_foundation_type",
@@ -6284,7 +6300,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10608"
         },
         {
           "name": "geometry_heated_basement",
@@ -6293,7 +6310,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10609"
         },
         {
           "name": "geometry_stories",
@@ -6302,7 +6320,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10610"
         },
         {
           "name": "geometry_building_floors",
@@ -6311,7 +6330,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10611"
         },
         {
           "name": "geometry_garage",
@@ -6320,7 +6340,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10612"
         },
         {
           "name": "geometry_house_size",
@@ -6329,7 +6350,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10613"
         },
         {
           "name": "geometry_shared_walls",
@@ -6338,7 +6360,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10614"
         },
         {
           "name": "geometry_shared_walls_sfa",
@@ -6347,7 +6370,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10615"
         },
         {
           "name": "geometry_shared_walls_mf",
@@ -6356,7 +6380,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10616"
         },
         {
           "name": "geometry_number_units_acs_bins",
@@ -6365,7 +6390,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10617"
         },
         {
           "name": "geometry_unit_stories_sf",
@@ -6374,7 +6400,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10618"
         },
         {
           "name": "geometry_unit_stories_mf",
@@ -6383,7 +6410,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10619"
         },
         {
           "name": "geometry_is_multifamily_low_rise",
@@ -6392,7 +6420,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10620"
         },
         {
           "name": "occupants",
@@ -6401,7 +6430,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10621"
         },
         {
           "name": "orientation",
@@ -6410,7 +6440,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10622"
         },
         {
           "name": "eaves",
@@ -6419,7 +6450,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10623"
         },
         {
           "name": "door_area",
@@ -6428,7 +6460,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10624"
         },
         {
           "name": "window_areas",
@@ -6437,7 +6470,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10625"
         },
         {
           "name": "overhangs",
@@ -6446,7 +6480,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10626"
         },
         {
           "name": "neighbors",
@@ -6455,7 +6490,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10627"
         },
         {
           "name": "insulation_unfinished_attic",
@@ -6464,7 +6500,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10628"
         },
         {
           "name": "insulation_finished_roof",
@@ -6473,7 +6510,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10629"
         },
         {
           "name": "roof_material",
@@ -6482,7 +6520,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10630"
         },
         {
           "name": "insulation_slab",
@@ -6491,7 +6530,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10631"
         },
         {
           "name": "insulation_crawlspace",
@@ -6500,7 +6540,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10632"
         },
         {
           "name": "insulation_unfinished_basement",
@@ -6509,7 +6550,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10633"
         },
         {
           "name": "insulation_finished_basement",
@@ -6518,7 +6560,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10634"
         },
         {
           "name": "insulation_pier_beam",
@@ -6527,7 +6570,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10635"
         },
         {
           "name": "insulation_interzonal_floor",
@@ -6536,7 +6580,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10636"
         },
         {
           "name": "insulation_wall",
@@ -6545,7 +6590,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10637"
         },
         {
           "name": "windows",
@@ -6554,7 +6600,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10638"
         },
         {
           "name": "doors",
@@ -6563,7 +6610,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10639"
         },
         {
           "name": "water_heater",
@@ -6572,7 +6620,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10640"
         },
         {
           "name": "hot_water_fixtures",
@@ -6581,7 +6630,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10641"
         },
         {
           "name": "hot_water_distribution",
@@ -6590,7 +6640,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10642"
         },
         {
           "name": "solar_hot_water",
@@ -6599,7 +6650,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10643"
         },
         {
           "name": "hvac_system_is_shared",
@@ -6608,7 +6660,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10644"
         },
         {
           "name": "hvac_system_shared_electricity",
@@ -6617,7 +6670,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10645"
         },
         {
           "name": "hvac_system_shared_natural_gas",
@@ -6626,7 +6680,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10646"
         },
         {
           "name": "hvac_system_shared_propane",
@@ -6635,7 +6690,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10647"
         },
         {
           "name": "hvac_system_shared_fuel_oil",
@@ -6644,7 +6700,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10648"
         },
         {
           "name": "hvac_system_shared_other_fuel",
@@ -6653,7 +6710,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10649"
         },
         {
           "name": "hvac_system_shared_none",
@@ -6662,7 +6720,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10650"
         },
         {
           "name": "hvac_system_is_heat_pump",
@@ -6671,7 +6730,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10651"
         },
         {
           "name": "hvac_system_heat_pump",
@@ -6680,7 +6740,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10652"
         },
         {
           "name": "hvac_system_heating_electricity",
@@ -6689,7 +6750,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10653"
         },
         {
           "name": "hvac_system_heating_natural_gas",
@@ -6698,7 +6760,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10654"
         },
         {
           "name": "hvac_system_heating_propane",
@@ -6707,7 +6770,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10655"
         },
         {
           "name": "hvac_system_heating_fuel_oil",
@@ -6716,7 +6780,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10656"
         },
         {
           "name": "hvac_system_heating_wood",
@@ -6725,7 +6790,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10657"
         },
         {
           "name": "hvac_system_heating_other_fuel",
@@ -6734,7 +6800,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10658"
         },
         {
           "name": "hvac_system_heating_none",
@@ -6743,7 +6810,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10659"
         },
         {
           "name": "hvac_system_cooling",
@@ -6752,7 +6820,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10660"
         },
         {
           "name": "hvac_system_cooling_type",
@@ -6761,7 +6830,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10661"
         },
         {
           "name": "heating_setpoint",
@@ -6770,7 +6840,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10662"
         },
         {
           "name": "cooling_setpoint",
@@ -6779,7 +6850,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10663"
         },
         {
           "name": "ceiling_fan",
@@ -6788,7 +6860,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10664"
         },
         {
           "name": "dehumidifier",
@@ -6797,7 +6870,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10665"
         },
         {
           "name": "refrigerator",
@@ -6806,7 +6880,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10666"
         },
         {
           "name": "cooking_range",
@@ -6815,7 +6890,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10667"
         },
         {
           "name": "dishwasher",
@@ -6824,7 +6900,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10668"
         },
         {
           "name": "clothes_washer",
@@ -6833,7 +6910,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10669"
         },
         {
           "name": "clothes_dryer",
@@ -6842,7 +6920,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10670"
         },
         {
           "name": "lighting",
@@ -6851,7 +6930,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10671"
         },
         {
           "name": "plug_loads",
@@ -6860,7 +6940,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10672"
         },
         {
           "name": "misc_extra_refrigerator",
@@ -6869,7 +6950,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10673"
         },
         {
           "name": "misc_freezer",
@@ -6878,7 +6960,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10674"
         },
         {
           "name": "misc_gas_fireplace",
@@ -6887,7 +6970,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10675"
         },
         {
           "name": "misc_gas_grill",
@@ -6896,7 +6980,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10676"
         },
         {
           "name": "misc_gas_lighting",
@@ -6905,7 +6990,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10677"
         },
         {
           "name": "misc_hot_tub_spa",
@@ -6914,7 +7000,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10678"
         },
         {
           "name": "misc_pool",
@@ -6923,7 +7010,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10679"
         },
         {
           "name": "misc_well_pump",
@@ -6932,7 +7020,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10680"
         },
         {
           "name": "ducts",
@@ -6941,7 +7030,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10681"
         },
         {
           "name": "infiltration",
@@ -6950,7 +7040,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10682"
         },
         {
           "name": "natural_ventilation",
@@ -6959,7 +7050,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10683"
         },
         {
           "name": "mechanical_ventilation",
@@ -6968,7 +7060,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10684"
         },
         {
           "name": "bathroom_spot_vent_hour",
@@ -6977,7 +7070,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10685"
         },
         {
           "name": "range_spot_vent_hour",
@@ -6986,7 +7080,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10686"
         },
         {
           "name": "pv",
@@ -6995,7 +7090,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10687"
         },
         {
           "name": "days_shifted",
@@ -7004,7 +7100,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10688"
         },
         {
           "name": "geometry_perimeter_footprint_ratio",
@@ -7013,7 +7110,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10689"
         },
         {
           "name": "location_city",
@@ -7022,7 +7120,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10690"
         },
         {
           "name": "location_state",
@@ -7031,7 +7130,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10691"
         },
         {
           "name": "location_latitude",
@@ -7040,7 +7140,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10692"
         },
         {
           "name": "location_longitude",
@@ -7049,7 +7150,30 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10693"
+        },
+        {
+          "name": "climate_zone_ba",
+          "display_name": "climate_zone_ba",
+          "short_name": "climate_zone_ba",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10694",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "climate_zone_iecc",
+          "display_name": "climate_zone_iecc",
+          "short_name": "climate_zone_iecc",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10695",
+          "checked": true,
+          "visualize": "true"
         },
         {
           "name": "units_represented",
@@ -7058,7 +7182,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10696"
         },
         {
           "name": "units_modeled",
@@ -7067,7 +7192,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10697"
         }
       ],
       "attributes": [
@@ -7090,13 +7216,13 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "4/19/2019",
+      "date": "4/30/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.15826000205442248,
+      "instanceId": 0.11611316906827374,
       "skip": false,
       "$$hashKey": "object:7673",
       "outputMeasure": true,
@@ -8245,6 +8371,28 @@
           "$$hashKey": "object:9143",
           "checked": true,
           "visualize": "true"
+        },
+        {
+          "name": "climate_zone_ba",
+          "display_name": "climate_zone_ba",
+          "short_name": "climate_zone_ba",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10694",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "climate_zone_iecc",
+          "display_name": "climate_zone_iecc",
+          "short_name": "climate_zone_iecc",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10695",
+          "checked": true,
+          "visualize": "true"
         }
       ]
     },
@@ -8973,7 +9121,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.0356839948996861,
+      "instanceId": 0.1742240119530314,
       "skip": false,
       "$$hashKey": "object:8631",
       "outputMeasure": true,
@@ -9792,7 +9940,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.717023619286103,
+      "instanceId": 0.21632973553942092,
       "skip": false,
       "$$hashKey": "object:8632",
       "outputMeasure": false
@@ -9839,7 +9987,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.14712434571973354,
+      "instanceId": 0.20187832718555998,
       "skip": false,
       "$$hashKey": "object:663249",
       "outputMeasure": false
@@ -9883,6 +10031,6 @@
     }
   },
   "designAlternatives": [],
-  "analysisID": null,
+  "analysisID": "",
   "datapoints": []
 }

--- a/project_testing/measures/BuildingCharacteristicsReport/measure.rb
+++ b/project_testing/measures/BuildingCharacteristicsReport/measure.rb
@@ -35,6 +35,8 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       "location_state",
       "location_latitude",
       "location_longitude",
+      "climate_zone_ba",
+      "climate_zone_iecc",
       "units_represented",
       "units_modeled"
     ]
@@ -104,6 +106,10 @@ class BuildingCharacteristicsReport < OpenStudio::Measure::ReportingMeasure
       runner.registerValue("location_latitude", weather.header.Latitude)
       runner.registerInfo("Registering #{weather.header.Longitude} for location_longitude.")
       runner.registerValue("location_longitude", weather.header.Longitude)
+      runner.registerInfo("Registering #{} for climate_zone_ba.")
+      runner.registerValue("climate_zone_ba", Location.get_climate_zone_ba(weather.header.Station))
+      runner.registerInfo("Registering #{} for climate_zone_iecc.")
+      runner.registerValue("climate_zone_iecc", Location.get_climate_zone_iecc(weather.header.Station))
     end
 
     units_represented = model.getBuilding.additionalProperties.getFeatureAsInteger("Total Units Represented")

--- a/project_testing/measures/BuildingCharacteristicsReport/measure.xml
+++ b/project_testing/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>5f3e6eca-2956-4387-9a46-eb44da9cf6a8</version_id>
-  <version_modified>20190419T174258Z</version_modified>
+  <version_id>3af85058-4f70-4faa-8ff1-47079020fbfa</version_id>
+  <version_modified>20190430T205639Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -726,6 +726,20 @@
       <model_dependent>false</model_dependent>
     </output>
     <output>
+      <name>climate_zone_ba</name>
+      <display_name>climate_zone_ba</display_name>
+      <short_name>climate_zone_ba</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>climate_zone_iecc</name>
+      <display_name>climate_zone_iecc</display_name>
+      <short_name>climate_zone_iecc</short_name>
+      <type>String</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
       <name>units_represented</name>
       <display_name>units_represented</display_name>
       <short_name>units_represented</short_name>
@@ -766,7 +780,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>80C0B14F</checksum>
+      <checksum>B2BFA13F</checksum>
     </file>
   </files>
 </measure>

--- a/project_testing/pat.json
+++ b/project_testing/pat.json
@@ -288,15 +288,15 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.05684063868124967,
+      "instanceId": 0.5260946213797741,
       "skip": false,
       "$$hashKey": "object:6784",
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\BuildExistingModel",
       "name": "build_existing_model",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\BuildExistingModel",
       "uid": "dedf59bb-3b88-4f16-8755-2c1ff5519cbf",
       "uuid": "{dedf59bb-3b88-4f16-8755-2c1ff5519cbf}",
       "version_id": "dcc77832-f110-4de8-a3c0-41b134c2a9a8",
@@ -447,16 +447,16 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.26173066349954865,
+      "instanceId": 0.8607667100439023,
       "skip": false,
       "$$hashKey": "object:6713",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\ApplyUpgrade",
       "name": "apply_upgrade",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\ApplyUpgrade",
       "uid": "33f1654c-f734-43d1-b35d-9d2856e41b5a",
       "uuid": "{33f1654c-f734-43d1-b35d-9d2856e41b5a}",
       "version_id": "9136d68f-bbdf-4548-993e-8912202b76ed",
@@ -3279,16 +3279,16 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.8702155195020949,
+      "instanceId": 0.4026589610475402,
       "skip": false,
       "$$hashKey": "object:7751",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\ApplyUpgrade",
       "name": "apply_upgrade_2",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/ApplyUpgrade",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\ApplyUpgrade",
       "uid": "33f1654c-f734-43d1-b35d-9d2856e41b5a",
       "uuid": "{33f1654c-f734-43d1-b35d-9d2856e41b5a}",
       "version_id": "9136d68f-bbdf-4548-993e-8912202b76ed",
@@ -6111,7 +6111,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.9207042108922512,
+      "instanceId": 0.43963788916623536,
       "skip": false,
       "$$hashKey": "object:10502",
       "showWarningText": false,
@@ -6123,9 +6123,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
-      "version_id": "5f3e6eca-2956-4387-9a46-eb44da9cf6a8",
-      "version_uuid": "{5f3e6eca-2956-4387-9a46-eb44da9cf6a8}",
-      "version_modified": "20190419T174258Z",
+      "version_id": "3af85058-4f70-4faa-8ff1-47079020fbfa",
+      "version_uuid": "{3af85058-4f70-4faa-8ff1-47079020fbfa}",
+      "version_modified": "20190430T205639Z",
       "xml_checksum": "2EA103AF",
       "display_name": "Building Characteristics Report",
       "class_name": "BuildingCharacteristicsReport",
@@ -6140,7 +6140,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10600"
         },
         {
           "name": "location_heating_region",
@@ -6149,7 +6150,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10601"
         },
         {
           "name": "location_cooling_region",
@@ -6158,7 +6160,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10602"
         },
         {
           "name": "location",
@@ -6167,7 +6170,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10603"
         },
         {
           "name": "location_weather_filename",
@@ -6176,7 +6180,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10604"
         },
         {
           "name": "location_weather_year",
@@ -6185,7 +6190,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10605"
         },
         {
           "name": "vintage",
@@ -6194,7 +6200,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10606"
         },
         {
           "name": "vintage_fpl",
@@ -6203,7 +6210,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10607"
         },
         {
           "name": "heating_fuel",
@@ -6212,7 +6220,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10608"
         },
         {
           "name": "usage_level",
@@ -6221,7 +6230,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10609"
         },
         {
           "name": "geometry_building_type",
@@ -6230,7 +6240,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10610"
         },
         {
           "name": "geometry_building_type_fpl",
@@ -6239,7 +6250,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10611"
         },
         {
           "name": "geometry_number_units",
@@ -6248,7 +6260,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10612"
         },
         {
           "name": "geometry_building_number_units_mf",
@@ -6257,7 +6270,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10613"
         },
         {
           "name": "geometry_building_number_units_sfa",
@@ -6266,7 +6280,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10614"
         },
         {
           "name": "geometry_building_number_units_hl",
@@ -6275,7 +6290,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10615"
         },
         {
           "name": "geometry_foundation_type",
@@ -6284,7 +6300,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10616"
         },
         {
           "name": "geometry_heated_basement",
@@ -6293,7 +6310,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10617"
         },
         {
           "name": "geometry_stories",
@@ -6302,7 +6320,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10618"
         },
         {
           "name": "geometry_building_floors",
@@ -6311,7 +6330,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10619"
         },
         {
           "name": "geometry_garage",
@@ -6320,7 +6340,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10620"
         },
         {
           "name": "geometry_house_size",
@@ -6329,7 +6350,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10621"
         },
         {
           "name": "geometry_shared_walls",
@@ -6338,7 +6360,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10622"
         },
         {
           "name": "geometry_shared_walls_sfa",
@@ -6347,7 +6370,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10623"
         },
         {
           "name": "geometry_shared_walls_mf",
@@ -6356,7 +6380,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10624"
         },
         {
           "name": "geometry_number_units_acs_bins",
@@ -6365,7 +6390,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10625"
         },
         {
           "name": "geometry_unit_stories_sf",
@@ -6374,7 +6400,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10626"
         },
         {
           "name": "geometry_unit_stories_mf",
@@ -6383,7 +6410,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10627"
         },
         {
           "name": "geometry_is_multifamily_low_rise",
@@ -6392,7 +6420,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10628"
         },
         {
           "name": "occupants",
@@ -6401,7 +6430,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10629"
         },
         {
           "name": "orientation",
@@ -6410,7 +6440,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10630"
         },
         {
           "name": "eaves",
@@ -6419,7 +6450,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10631"
         },
         {
           "name": "door_area",
@@ -6428,7 +6460,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10632"
         },
         {
           "name": "window_areas",
@@ -6437,7 +6470,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10633"
         },
         {
           "name": "overhangs",
@@ -6446,7 +6480,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10634"
         },
         {
           "name": "neighbors",
@@ -6455,7 +6490,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10635"
         },
         {
           "name": "insulation_unfinished_attic",
@@ -6464,7 +6500,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10636"
         },
         {
           "name": "insulation_finished_roof",
@@ -6473,7 +6510,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10637"
         },
         {
           "name": "roof_material",
@@ -6482,7 +6520,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10638"
         },
         {
           "name": "insulation_slab",
@@ -6491,7 +6530,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10639"
         },
         {
           "name": "insulation_crawlspace",
@@ -6500,7 +6540,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10640"
         },
         {
           "name": "insulation_unfinished_basement",
@@ -6509,7 +6550,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10641"
         },
         {
           "name": "insulation_finished_basement",
@@ -6518,7 +6560,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10642"
         },
         {
           "name": "insulation_pier_beam",
@@ -6527,7 +6570,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10643"
         },
         {
           "name": "insulation_interzonal_floor",
@@ -6536,7 +6580,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10644"
         },
         {
           "name": "insulation_wall",
@@ -6545,7 +6590,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10645"
         },
         {
           "name": "windows",
@@ -6554,7 +6600,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10646"
         },
         {
           "name": "doors",
@@ -6563,7 +6610,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10647"
         },
         {
           "name": "water_heater",
@@ -6572,7 +6620,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10648"
         },
         {
           "name": "hot_water_fixtures",
@@ -6581,7 +6630,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10649"
         },
         {
           "name": "hot_water_distribution",
@@ -6590,7 +6640,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10650"
         },
         {
           "name": "solar_hot_water",
@@ -6599,7 +6650,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10651"
         },
         {
           "name": "hvac_system_is_shared",
@@ -6608,7 +6660,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10652"
         },
         {
           "name": "hvac_system_shared_electricity",
@@ -6617,7 +6670,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10653"
         },
         {
           "name": "hvac_system_shared_natural_gas",
@@ -6626,7 +6680,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10654"
         },
         {
           "name": "hvac_system_shared_propane",
@@ -6635,7 +6690,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10655"
         },
         {
           "name": "hvac_system_shared_fuel_oil",
@@ -6644,7 +6700,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10656"
         },
         {
           "name": "hvac_system_shared_other_fuel",
@@ -6653,7 +6710,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10657"
         },
         {
           "name": "hvac_system_shared_none",
@@ -6662,7 +6720,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10658"
         },
         {
           "name": "hvac_system_is_heat_pump",
@@ -6671,7 +6730,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10659"
         },
         {
           "name": "hvac_system_heat_pump",
@@ -6680,7 +6740,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10660"
         },
         {
           "name": "hvac_system_heating_electricity",
@@ -6689,7 +6750,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10661"
         },
         {
           "name": "hvac_system_heating_natural_gas",
@@ -6698,7 +6760,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10662"
         },
         {
           "name": "hvac_system_heating_propane",
@@ -6707,7 +6770,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10663"
         },
         {
           "name": "hvac_system_heating_fuel_oil",
@@ -6716,7 +6780,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10664"
         },
         {
           "name": "hvac_system_heating_wood",
@@ -6725,7 +6790,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10665"
         },
         {
           "name": "hvac_system_heating_other_fuel",
@@ -6734,7 +6800,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10666"
         },
         {
           "name": "hvac_system_heating_none",
@@ -6743,7 +6810,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10667"
         },
         {
           "name": "hvac_system_cooling",
@@ -6752,7 +6820,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10668"
         },
         {
           "name": "hvac_system_cooling_type",
@@ -6761,7 +6830,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10669"
         },
         {
           "name": "heating_setpoint",
@@ -6770,7 +6840,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10670"
         },
         {
           "name": "cooling_setpoint",
@@ -6779,7 +6850,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10671"
         },
         {
           "name": "ceiling_fan",
@@ -6788,7 +6860,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10672"
         },
         {
           "name": "dehumidifier",
@@ -6797,7 +6870,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10673"
         },
         {
           "name": "refrigerator",
@@ -6806,7 +6880,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10674"
         },
         {
           "name": "cooking_range",
@@ -6815,7 +6890,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10675"
         },
         {
           "name": "dishwasher",
@@ -6824,7 +6900,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10676"
         },
         {
           "name": "clothes_washer",
@@ -6833,7 +6910,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10677"
         },
         {
           "name": "clothes_dryer",
@@ -6842,7 +6920,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10678"
         },
         {
           "name": "lighting",
@@ -6851,7 +6930,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10679"
         },
         {
           "name": "plug_loads",
@@ -6860,7 +6940,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10680"
         },
         {
           "name": "misc_extra_refrigerator",
@@ -6869,7 +6950,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10681"
         },
         {
           "name": "misc_freezer",
@@ -6878,7 +6960,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10682"
         },
         {
           "name": "misc_gas_fireplace",
@@ -6887,7 +6970,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10683"
         },
         {
           "name": "misc_gas_grill",
@@ -6896,7 +6980,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10684"
         },
         {
           "name": "misc_gas_lighting",
@@ -6905,7 +6990,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10685"
         },
         {
           "name": "misc_hot_tub_spa",
@@ -6914,7 +7000,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10686"
         },
         {
           "name": "misc_pool",
@@ -6923,7 +7010,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10687"
         },
         {
           "name": "misc_well_pump",
@@ -6932,7 +7020,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10688"
         },
         {
           "name": "ducts",
@@ -6941,7 +7030,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10689"
         },
         {
           "name": "infiltration",
@@ -6950,7 +7040,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10690"
         },
         {
           "name": "natural_ventilation",
@@ -6959,7 +7050,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10691"
         },
         {
           "name": "mechanical_ventilation",
@@ -6968,7 +7060,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10692"
         },
         {
           "name": "bathroom_spot_vent_hour",
@@ -6977,7 +7070,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10693"
         },
         {
           "name": "range_spot_vent_hour",
@@ -6986,7 +7080,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10694"
         },
         {
           "name": "pv",
@@ -6995,7 +7090,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10695"
         },
         {
           "name": "days_shifted",
@@ -7004,7 +7100,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10696"
         },
         {
           "name": "geometry_perimeter_footprint_ratio",
@@ -7013,7 +7110,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10697"
         },
         {
           "name": "location_city",
@@ -7022,7 +7120,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10698"
         },
         {
           "name": "location_state",
@@ -7031,7 +7130,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10699"
         },
         {
           "name": "location_latitude",
@@ -7040,7 +7140,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10700"
         },
         {
           "name": "location_longitude",
@@ -7049,7 +7150,36 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10701"
+        },
+        {
+          "name": "climate_zone_ba",
+          "display_name": "climate_zone_ba",
+          "short_name": "climate_zone_ba",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10702",
+          "checked": true,
+          "visualize": "true",
+          "measure_name": "building_characteristics_report",
+          "measure_class_name": "BuildingCharacteristicsReport",
+          "measure_uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67"
+        },
+        {
+          "name": "climate_zone_iecc",
+          "display_name": "climate_zone_iecc",
+          "short_name": "climate_zone_iecc",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10703",
+          "checked": true,
+          "visualize": "true",
+          "measure_name": "building_characteristics_report",
+          "measure_class_name": "BuildingCharacteristicsReport",
+          "measure_uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67"
         },
         {
           "name": "units_represented",
@@ -7058,7 +7188,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10704"
         },
         {
           "name": "units_modeled",
@@ -7067,7 +7198,8 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "checked": true
+          "checked": true,
+          "$$hashKey": "object:10705"
         }
       ],
       "attributes": [
@@ -7090,13 +7222,13 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "4/19/2019",
+      "date": "4/30/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.5965687598961711,
+      "instanceId": 0.42485904248730444,
       "skip": false,
       "$$hashKey": "object:7697",
       "outputMeasure": true,
@@ -8557,6 +8689,34 @@
           "measure_name": "building_characteristics_report",
           "measure_class_name": "BuildingCharacteristicsReport",
           "measure_uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67"
+        },
+        {
+          "name": "climate_zone_ba",
+          "display_name": "climate_zone_ba",
+          "short_name": "climate_zone_ba",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10702",
+          "checked": true,
+          "visualize": "true",
+          "measure_name": "building_characteristics_report",
+          "measure_class_name": "BuildingCharacteristicsReport",
+          "measure_uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67"
+        },
+        {
+          "name": "climate_zone_iecc",
+          "display_name": "climate_zone_iecc",
+          "short_name": "climate_zone_iecc",
+          "description": "",
+          "type": "String",
+          "model_dependent": false,
+          "$$hashKey": "object:10703",
+          "checked": true,
+          "visualize": "true",
+          "measure_name": "building_characteristics_report",
+          "measure_class_name": "BuildingCharacteristicsReport",
+          "measure_uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67"
         }
       ]
     },
@@ -9285,7 +9445,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.4269399954895099,
+      "instanceId": 0.41911987295703423,
       "skip": false,
       "$$hashKey": "object:7698",
       "outputMeasure": true,
@@ -10290,7 +10450,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.3396065878757324,
+      "instanceId": 0.08041166720665083,
       "skip": false,
       "$$hashKey": "object:7699",
       "outputMeasure": false
@@ -10337,7 +10497,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.13580932788302613,
+      "instanceId": 0.6522178617724304,
       "skip": false,
       "$$hashKey": "object:512021",
       "outputMeasure": false

--- a/resources/measures/HPXMLtoOpenStudio/resources/location.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/location.rb
@@ -180,11 +180,6 @@ class Location
       end
     end
 
-    if iecc_zone.length == 1
-      iecc_zone += "A" # for 7 and 8, A and B don't matter in terms of autosizing
-    end
-    iecc_zone = "ASHRAE 169-2006-#{iecc_zone}"
-
     return iecc_zone
   end
 end


### PR DESCRIPTION
In response to:
* Chuck
* Ed

This is a pretty simple and straightforward PR: it adds two columns "climate_zone_ba" and "climate_zone_iecc" (based on the epw) to the results csv.

@ejhw 