### PR TITLE
Adds integrity checks for names with illegal characters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -318,12 +318,16 @@ def integrity_check_options_lookup_tsv(project_dir_name, housing_characteristics
   # Gather all options/arguments
   parameter_names = get_parameters_ordered_from_options_lookup_tsv(lookup_file)
   parameter_names.each do |parameter_name|
+    check_for_illegal_chars(parameter_name, 'parameter')
+    
     tsvpath = File.join(project_dir_name, housing_characteristics_dir, "#{parameter_name}.tsv")
     next if not File.exist?(tsvpath) # Not every parameter used by every project
 
     option_names = get_options_for_parameter_from_options_lookup_tsv(lookup_file, parameter_name)
     options_measure_args = get_measure_args_from_option_names(lookup_file, option_names, parameter_name, nil)
     option_names.each do |option_name|
+      check_for_illegal_chars(option_name, 'option')
+
       # Check for (parameter, option) names
       # Get measure name and arguments associated with the option
       options_measure_args[option_name].each do |measure_subdir, args_hash|
@@ -393,6 +397,16 @@ def integrity_check_options_lookup_tsv(project_dir_name, housing_characteristics
     all_measure_args.shuffle.each_with_index do |measure_args, idx|
       validate_measure_args(measure_instance.arguments(model), measure_args, lookup_file, measure_subdir, nil)
     end
+  end
+end
+
+def check_for_illegal_chars(name, name_type)
+  # Check for illegal characters in parameter/option names. These characters are
+  # reserved for use in the apply upgrade logic.
+  ['(', ')', '|', '&'].each do |char|
+    next unless name.include? char
+    
+    raise "ERROR: Illegal character ('#{char}') found in #{name_type} name '#{name}'."
   end
 end
 


### PR DESCRIPTION
Integrity checks now look for illegal characters (`(`, `)`, `&`, and `|`) in either parameter or option names in the options_lookup.tsv.