### PR TITLE
Lighting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features
 - Separate tsv files for bedrooms, cooking range schedule, corridor, holiday lighting, interior/other lighting use, pool schedule, plug loads schedule, and refrigeration schedule ([#338](https://github.com/NREL/OpenStudio-BuildStock/pull/338))
 
 Fixes
+- Fixes for custom output meters: total site electricity double-counting exterior holiday lighting, and garage lighting all zeroes ([#349](https://github.com/NREL/OpenStudio-BuildStock/pull/349))
 - Remove shared facades tsv files from the multifamily_beta and testing projects ([#301](https://github.com/NREL/OpenStudio-BuildStock/pull/301))
 - Move redundant output meter code from individual reporting measures out into shared resource file ([#334](https://github.com/NREL/OpenStudio-BuildStock/pull/334))
 - Fix for the power outages measure where the last hour of the day was not getting the new schedule applied ([#238](https://github.com/NREL/OpenStudio-BuildStock/pull/238))

--- a/docs/read_the_docs/source/tutorial/setup_analysis_project.rst
+++ b/docs/read_the_docs/source/tutorial/setup_analysis_project.rst
@@ -216,6 +216,8 @@ End uses include:
   * central system cooling [electric] [kWh]
   * interior lighting [kWh]
   * exterior lighting [kWh]
+  * exterior holiday lighting [kWh]
+  * garage lighting [kWh]
   * interior equipment [electric/gas/oil/propane] [kWh/therm/MBtu/MBtu]
   * fans heating [kWh]
   * fans cooling [kWh]
@@ -257,9 +259,7 @@ End uses include:
   * gas grill [therm]
   * gas lighting [therm]
   * gas fireplace [therm]
-  * well pump [kWh]
-  * garage lighting [kWh]
-  * exterior holiday lighting [kWh]
+  * well pump [kWh]  
   
 **Output Variables**
   If you choose to report any output variables (e.g., "Zone Air Temperature" or "Site Outdoor Air Humidity Ratio"), enter a comma-separated list of output variable names. A list of available output variables can be viewed in EnergyPlus's ``.rdd`` file.

--- a/measures/SimulationOutputReport/measure.rb
+++ b/measures/SimulationOutputReport/measure.rb
@@ -74,6 +74,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "electricity_central_system_cooling_kwh",
       "electricity_interior_lighting_kwh",
       "electricity_exterior_lighting_kwh",
+      "electricity_exterior_holiday_lighting_kwh",
+      "electricity_garage_lighting_kwh",
       "electricity_interior_equipment_kwh",
       "electricity_fans_heating_kwh",
       "electricity_fans_cooling_kwh",

--- a/measures/SimulationOutputReport/measure.rb
+++ b/measures/SimulationOutputReport/measure.rb
@@ -193,7 +193,6 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # ELECTRICITY
 
-    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "total_site_electricity_kwh", electricity.total_end_uses[0], "GJ", elec_site_units)
     report_sim_output(runner, "net_site_electricity_kwh", electricity.total_end_uses[0] - electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_heating_kwh", electricity.heating[0], "GJ", elec_site_units)
@@ -202,8 +201,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_cooling_kwh", electricity.central_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_lighting_kwh", electricity.interior_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_exterior_lighting_kwh", electricity.exterior_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_garage_lighting_kwh", electricity.garage_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_equipment_kwh", electricity.interior_equipment[0], "GJ", elec_site_units)
-    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
 
     # Initialize variables to check against sql file totals
     env_period_ix_query = "SELECT EnvironmentPeriodIndex FROM EnvironmentPeriods WHERE EnvironmentName='#{ann_env_pd}'"
@@ -261,6 +261,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_pumps_heating_kwh", electricity.central_pumps_heating[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_pumps_cooling_kwh", electricity.pumps_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_central_system_pumps_cooling_kwh", electricity.central_pumps_cooling[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
 
     # NATURAL GAS
 

--- a/measures/SimulationOutputReport/measure.xml
+++ b/measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>a76e6c10-23a1-4159-b3a3-693195d53895</version_id>
-  <version_modified>20191029T171022Z</version_modified>
+  <version_id>248dd826-3c23-4f7d-952b-a25270cedf6c</version_id>
+  <version_modified>20191210T205437Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
@@ -779,7 +779,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9C639C14</checksum>
+      <checksum>7C94B667</checksum>
     </file>
   </files>
 </measure>

--- a/measures/SimulationOutputReport/measure.xml
+++ b/measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>248dd826-3c23-4f7d-952b-a25270cedf6c</version_id>
-  <version_modified>20191210T205437Z</version_modified>
+  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
@@ -99,6 +99,20 @@
       <name>electricity_exterior_lighting_kwh</name>
       <display_name>electricity_exterior_lighting_kwh</display_name>
       <short_name>electricity_exterior_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_exterior_holiday_lighting_kwh</name>
+      <display_name>electricity_exterior_holiday_lighting_kwh</display_name>
+      <short_name>electricity_exterior_holiday_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_garage_lighting_kwh</name>
+      <display_name>electricity_garage_lighting_kwh</display_name>
+      <short_name>electricity_garage_lighting_kwh</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -779,7 +793,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>7C94B667</checksum>
+      <checksum>0EBF3BC0</checksum>
     </file>
   </files>
 </measure>

--- a/measures/TimeseriesCSVExport/measure.rb
+++ b/measures/TimeseriesCSVExport/measure.rb
@@ -203,6 +203,8 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "electricity_central_system_cooling_kwh", electricity.central_cooling, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_lighting_kwh", electricity.interior_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_exterior_lighting_kwh", electricity.exterior_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_equipment_kwh", electricity.interior_equipment, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_heating_kwh", electricity.fans_heating, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_cooling_kwh", electricity.fans_cooling, "GJ", elec_site_units)
@@ -276,8 +278,6 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
       report_ts_output(runner, timeseries, "natural_gas_lighting_therm", natural_gas.lighting, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "natural_gas_fireplace_therm", natural_gas.fireplace, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "electricity_well_pump_kwh", electricity.well_pump, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
     end
 
     output_vars.each do |output_var|

--- a/measures/TimeseriesCSVExport/measure.xml
+++ b/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>7d687785-9dfb-47b6-84c1-3775bd638174</version_id>
-  <version_modified>20191029T154255Z</version_modified>
+  <version_id>6b1654cf-d1c5-4f08-bf6f-b2f40c608634</version_id>
+  <version_modified>20191210T204859Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -93,7 +93,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E2397EB2</checksum>
+      <checksum>6C92E878</checksum>
     </file>
   </files>
 </measure>

--- a/measures/TimeseriesCSVExport/measure.xml
+++ b/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>6b1654cf-d1c5-4f08-bf6f-b2f40c608634</version_id>
-  <version_modified>20191210T204859Z</version_modified>
+  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,12 +79,6 @@
   </attributes>
   <files>
     <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>B94D34E1</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -94,6 +88,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>6C92E878</checksum>
+    </file>
+    <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F8C982FF</checksum>
     </file>
   </files>
 </measure>

--- a/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_multifamily_beta/measures/SimulationOutputReport/measure.rb
+++ b/project_multifamily_beta/measures/SimulationOutputReport/measure.rb
@@ -74,6 +74,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "electricity_central_system_cooling_kwh",
       "electricity_interior_lighting_kwh",
       "electricity_exterior_lighting_kwh",
+      "electricity_exterior_holiday_lighting_kwh",
+      "electricity_garage_lighting_kwh",
       "electricity_interior_equipment_kwh",
       "electricity_fans_heating_kwh",
       "electricity_fans_cooling_kwh",
@@ -193,7 +195,6 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # ELECTRICITY
 
-    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "total_site_electricity_kwh", electricity.total_end_uses[0], "GJ", elec_site_units)
     report_sim_output(runner, "net_site_electricity_kwh", electricity.total_end_uses[0] - electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_heating_kwh", electricity.heating[0], "GJ", elec_site_units)
@@ -202,8 +203,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_cooling_kwh", electricity.central_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_lighting_kwh", electricity.interior_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_exterior_lighting_kwh", electricity.exterior_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_garage_lighting_kwh", electricity.garage_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_equipment_kwh", electricity.interior_equipment[0], "GJ", elec_site_units)
-    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
 
     # Initialize variables to check against sql file totals
     env_period_ix_query = "SELECT EnvironmentPeriodIndex FROM EnvironmentPeriods WHERE EnvironmentName='#{ann_env_pd}'"
@@ -261,6 +263,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_pumps_heating_kwh", electricity.central_pumps_heating[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_pumps_cooling_kwh", electricity.pumps_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_central_system_pumps_cooling_kwh", electricity.central_pumps_cooling[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
 
     # NATURAL GAS
 

--- a/project_multifamily_beta/measures/SimulationOutputReport/measure.xml
+++ b/project_multifamily_beta/measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>a76e6c10-23a1-4159-b3a3-693195d53895</version_id>
-  <version_modified>20191029T171022Z</version_modified>
+  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
@@ -99,6 +99,20 @@
       <name>electricity_exterior_lighting_kwh</name>
       <display_name>electricity_exterior_lighting_kwh</display_name>
       <short_name>electricity_exterior_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_exterior_holiday_lighting_kwh</name>
+      <display_name>electricity_exterior_holiday_lighting_kwh</display_name>
+      <short_name>electricity_exterior_holiday_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_garage_lighting_kwh</name>
+      <display_name>electricity_garage_lighting_kwh</display_name>
+      <short_name>electricity_garage_lighting_kwh</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -779,7 +793,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9C639C14</checksum>
+      <checksum>0EBF3BC0</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/measure.rb
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/measure.rb
@@ -203,6 +203,8 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "electricity_central_system_cooling_kwh", electricity.central_cooling, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_lighting_kwh", electricity.interior_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_exterior_lighting_kwh", electricity.exterior_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_equipment_kwh", electricity.interior_equipment, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_heating_kwh", electricity.fans_heating, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_cooling_kwh", electricity.fans_cooling, "GJ", elec_site_units)
@@ -276,8 +278,6 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
       report_ts_output(runner, timeseries, "natural_gas_lighting_therm", natural_gas.lighting, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "natural_gas_fireplace_therm", natural_gas.fireplace, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "electricity_well_pump_kwh", electricity.well_pump, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
     end
 
     output_vars.each do |output_var|

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/measure.xml
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>7d687785-9dfb-47b6-84c1-3775bd638174</version_id>
-  <version_modified>20191029T154255Z</version_modified>
+  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,12 +79,6 @@
   </attributes>
   <files>
     <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>B94D34E1</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -93,7 +87,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E2397EB2</checksum>
+      <checksum>6C92E878</checksum>
+    </file>
+    <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F8C982FF</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_multifamily_beta/pat.json
+++ b/project_multifamily_beta/pat.json
@@ -312,7 +312,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.4988169539597487,
+      "instanceId": 0.07177736855592243,
       "skip": false,
       "$$hashKey": "object:11247",
       "outputMeasure": false
@@ -494,7 +494,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.8221779906442876,
+      "instanceId": 0.5062193363918583,
       "skip": false,
       "$$hashKey": "object:32852",
       "showWarningText": false,
@@ -7316,7 +7316,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.8254606133465572,
+      "instanceId": 0.7596869052769928,
       "skip": false,
       "$$hashKey": "object:32853",
       "showWarningText": false,
@@ -14138,7 +14138,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.6582546148918529,
+      "instanceId": 0.7421390352061279,
       "skip": false,
       "$$hashKey": "object:39018",
       "showWarningText": false,
@@ -14147,7 +14147,7 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildingCharacteristicsReport",
       "name": "building_characteristics_report",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
       "version_id": "96e57a64-ab28-49aa-87de-41cb2c1f3c15",
@@ -15584,7 +15584,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.8879904679579618,
+      "instanceId": 0.7807747349185095,
       "skip": false,
       "$$hashKey": "object:14900",
       "outputMeasure": true,
@@ -16995,9 +16995,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/SimulationOutputReport",
       "uid": "fc337100-8634-404e-8966-01243d292a79",
       "uuid": "{fc337100-8634-404e-8966-01243d292a79}",
-      "version_id": "a76e6c10-23a1-4159-b3a3-693195d53895",
-      "version_uuid": "{a76e6c10-23a1-4159-b3a3-693195d53895}",
-      "version_modified": "20191029T171022Z",
+      "version_id": "452c3c75-928b-4c49-93f5-dc319088b009",
+      "version_uuid": "{452c3c75-928b-4c49-93f5-dc319088b009}",
+      "version_modified": "20191210T220251Z",
       "xml_checksum": "2C8A3EEF",
       "display_name": "Simulation Output Report",
       "class_name": "SimulationOutputReport",
@@ -17012,7 +17012,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19070",
+          "$$hashKey": "object:17681",
           "checked": true,
           "visualize": "true"
         },
@@ -17023,7 +17023,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19071",
+          "$$hashKey": "object:17682",
           "checked": true,
           "visualize": "true"
         },
@@ -17034,7 +17034,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19072",
+          "$$hashKey": "object:17683",
           "checked": true,
           "visualize": "true"
         },
@@ -17045,7 +17045,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19073",
+          "$$hashKey": "object:17684",
           "checked": true,
           "visualize": "true"
         },
@@ -17056,7 +17056,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19074",
+          "$$hashKey": "object:17685",
           "checked": true,
           "visualize": "true"
         },
@@ -17067,7 +17067,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19075",
+          "$$hashKey": "object:17686",
           "checked": true,
           "visualize": "true"
         },
@@ -17078,7 +17078,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19076",
+          "$$hashKey": "object:17687",
           "checked": true,
           "visualize": "true"
         },
@@ -17089,7 +17089,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19077",
+          "$$hashKey": "object:17688",
           "checked": true,
           "visualize": "true"
         },
@@ -17100,7 +17100,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19078",
+          "$$hashKey": "object:17689",
           "checked": true,
           "visualize": "true"
         },
@@ -17111,7 +17111,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19079",
+          "$$hashKey": "object:17690",
           "checked": true,
           "visualize": "true"
         },
@@ -17122,7 +17122,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19080",
+          "$$hashKey": "object:17691",
           "checked": true,
           "visualize": "true"
         },
@@ -17133,7 +17133,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19081",
+          "$$hashKey": "object:17692",
           "checked": true,
           "visualize": "true"
         },
@@ -17144,7 +17144,29 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19082",
+          "$$hashKey": "object:17693",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_exterior_holiday_lighting_kwh",
+          "display_name": "electricity_exterior_holiday_lighting_kwh",
+          "short_name": "electricity_exterior_holiday_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:17694",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_garage_lighting_kwh",
+          "display_name": "electricity_garage_lighting_kwh",
+          "short_name": "electricity_garage_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:17695",
           "checked": true,
           "visualize": "true"
         },
@@ -17155,7 +17177,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19083",
+          "$$hashKey": "object:17696",
           "checked": true,
           "visualize": "true"
         },
@@ -17166,7 +17188,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19084",
+          "$$hashKey": "object:17697",
           "checked": true,
           "visualize": "true"
         },
@@ -17177,7 +17199,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19085",
+          "$$hashKey": "object:17698",
           "checked": true,
           "visualize": "true"
         },
@@ -17188,7 +17210,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19086",
+          "$$hashKey": "object:17699",
           "checked": true,
           "visualize": "true"
         },
@@ -17199,7 +17221,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19087",
+          "$$hashKey": "object:17700",
           "checked": true,
           "visualize": "true"
         },
@@ -17210,7 +17232,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19088",
+          "$$hashKey": "object:17701",
           "checked": true,
           "visualize": "true"
         },
@@ -17221,7 +17243,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19089",
+          "$$hashKey": "object:17702",
           "checked": true,
           "visualize": "true"
         },
@@ -17232,7 +17254,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19090",
+          "$$hashKey": "object:17703",
           "checked": true,
           "visualize": "true"
         },
@@ -17243,7 +17265,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19091",
+          "$$hashKey": "object:17704",
           "checked": true,
           "visualize": "true"
         },
@@ -17254,7 +17276,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19092",
+          "$$hashKey": "object:17705",
           "checked": true,
           "visualize": "true"
         },
@@ -17265,7 +17287,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19093",
+          "$$hashKey": "object:17706",
           "checked": true,
           "visualize": "true"
         },
@@ -17276,7 +17298,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19094",
+          "$$hashKey": "object:17707",
           "checked": true,
           "visualize": "true"
         },
@@ -17287,7 +17309,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19095",
+          "$$hashKey": "object:17708",
           "checked": true,
           "visualize": "true"
         },
@@ -17298,7 +17320,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19096",
+          "$$hashKey": "object:17709",
           "checked": true,
           "visualize": "true"
         },
@@ -17309,7 +17331,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19097",
+          "$$hashKey": "object:17710",
           "checked": true,
           "visualize": "true"
         },
@@ -17320,7 +17342,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19098",
+          "$$hashKey": "object:17711",
           "checked": true,
           "visualize": "true"
         },
@@ -17331,7 +17353,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19099",
+          "$$hashKey": "object:17712",
           "checked": true,
           "visualize": "true"
         },
@@ -17342,7 +17364,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19100",
+          "$$hashKey": "object:17713",
           "checked": true,
           "visualize": "true"
         },
@@ -17353,7 +17375,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19101",
+          "$$hashKey": "object:17714",
           "checked": true,
           "visualize": "true"
         },
@@ -17364,7 +17386,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19102",
+          "$$hashKey": "object:17715",
           "checked": true,
           "visualize": "true"
         },
@@ -17375,7 +17397,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19103",
+          "$$hashKey": "object:17716",
           "checked": true,
           "visualize": "true"
         },
@@ -17386,7 +17408,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19104",
+          "$$hashKey": "object:17717",
           "checked": true,
           "visualize": "true"
         },
@@ -17397,7 +17419,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19105",
+          "$$hashKey": "object:17718",
           "checked": true,
           "visualize": "true"
         },
@@ -17408,7 +17430,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19106",
+          "$$hashKey": "object:17719",
           "checked": true,
           "visualize": "true"
         },
@@ -17419,7 +17441,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19107",
+          "$$hashKey": "object:17720",
           "checked": true,
           "visualize": "true"
         },
@@ -17430,7 +17452,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19108",
+          "$$hashKey": "object:17721",
           "checked": true,
           "visualize": "true"
         },
@@ -17441,7 +17463,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19109",
+          "$$hashKey": "object:17722",
           "checked": true,
           "visualize": "true"
         },
@@ -17452,7 +17474,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19110",
+          "$$hashKey": "object:17723",
           "checked": true,
           "visualize": "true"
         },
@@ -17463,7 +17485,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19111",
+          "$$hashKey": "object:17724",
           "checked": true,
           "visualize": "true"
         },
@@ -17474,7 +17496,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19112",
+          "$$hashKey": "object:17725",
           "checked": true,
           "visualize": "true"
         },
@@ -17485,7 +17507,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19113",
+          "$$hashKey": "object:17726",
           "checked": true,
           "visualize": "true"
         },
@@ -17496,7 +17518,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19114",
+          "$$hashKey": "object:17727",
           "checked": true,
           "visualize": "true"
         },
@@ -17507,7 +17529,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19115",
+          "$$hashKey": "object:17728",
           "checked": true,
           "visualize": "true"
         },
@@ -17518,7 +17540,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19116",
+          "$$hashKey": "object:17729",
           "checked": true,
           "visualize": "true"
         },
@@ -17529,7 +17551,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19117",
+          "$$hashKey": "object:17730",
           "checked": true,
           "visualize": "true"
         },
@@ -17540,7 +17562,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19118",
+          "$$hashKey": "object:17731",
           "checked": true,
           "visualize": "true"
         },
@@ -17551,7 +17573,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19119",
+          "$$hashKey": "object:17732",
           "checked": true,
           "visualize": "true"
         },
@@ -17562,7 +17584,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19120",
+          "$$hashKey": "object:17733",
           "checked": true,
           "visualize": "true"
         },
@@ -17573,7 +17595,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19121",
+          "$$hashKey": "object:17734",
           "checked": true,
           "visualize": "true"
         },
@@ -17584,7 +17606,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19122",
+          "$$hashKey": "object:17735",
           "checked": true,
           "visualize": "true"
         },
@@ -17595,7 +17617,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19123",
+          "$$hashKey": "object:17736",
           "checked": true,
           "visualize": "true"
         },
@@ -17606,7 +17628,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19124",
+          "$$hashKey": "object:17737",
           "checked": true,
           "visualize": "true"
         },
@@ -17617,7 +17639,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19125",
+          "$$hashKey": "object:17738",
           "checked": true,
           "visualize": "true"
         },
@@ -17628,7 +17650,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19126",
+          "$$hashKey": "object:17739",
           "checked": true,
           "visualize": "true"
         },
@@ -17639,7 +17661,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19127",
+          "$$hashKey": "object:17740",
           "checked": true,
           "visualize": "true"
         },
@@ -17650,7 +17672,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19128",
+          "$$hashKey": "object:17741",
           "checked": true,
           "visualize": "true"
         },
@@ -17661,7 +17683,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19129",
+          "$$hashKey": "object:17742",
           "checked": true,
           "visualize": "true"
         },
@@ -17672,7 +17694,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19130",
+          "$$hashKey": "object:17743",
           "checked": true,
           "visualize": "true"
         },
@@ -17683,7 +17705,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19131",
+          "$$hashKey": "object:17744",
           "checked": true,
           "visualize": "true"
         },
@@ -17694,7 +17716,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19132",
+          "$$hashKey": "object:17745",
           "checked": true,
           "visualize": "true"
         },
@@ -17705,7 +17727,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19133",
+          "$$hashKey": "object:17746",
           "checked": true,
           "visualize": "true"
         },
@@ -17716,7 +17738,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19134",
+          "$$hashKey": "object:17747",
           "checked": true,
           "visualize": "true"
         },
@@ -17727,7 +17749,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19135",
+          "$$hashKey": "object:17748",
           "checked": true,
           "visualize": "true"
         },
@@ -17738,7 +17760,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19136",
+          "$$hashKey": "object:17749",
           "checked": true,
           "visualize": "true"
         },
@@ -17749,7 +17771,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19137",
+          "$$hashKey": "object:17750",
           "checked": true,
           "visualize": "true"
         },
@@ -17760,7 +17782,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19138",
+          "$$hashKey": "object:17751",
           "checked": true,
           "visualize": "true"
         },
@@ -17771,7 +17793,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19139",
+          "$$hashKey": "object:17752",
           "checked": true,
           "visualize": "true"
         },
@@ -17782,7 +17804,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19140",
+          "$$hashKey": "object:17753",
           "checked": true,
           "visualize": "true"
         },
@@ -17793,7 +17815,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19141",
+          "$$hashKey": "object:17754",
           "checked": true,
           "visualize": "true"
         },
@@ -17804,7 +17826,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19142",
+          "$$hashKey": "object:17755",
           "checked": true,
           "visualize": "true"
         },
@@ -17815,7 +17837,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19143",
+          "$$hashKey": "object:17756",
           "checked": true,
           "visualize": "true"
         },
@@ -17826,7 +17848,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19144",
+          "$$hashKey": "object:17757",
           "checked": true,
           "visualize": "true"
         },
@@ -17837,7 +17859,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19145",
+          "$$hashKey": "object:17758",
           "checked": true,
           "visualize": "true"
         },
@@ -17848,7 +17870,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19146",
+          "$$hashKey": "object:17759",
           "checked": true,
           "visualize": "true"
         },
@@ -17859,7 +17881,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19147",
+          "$$hashKey": "object:17760",
           "checked": true,
           "visualize": "true"
         },
@@ -17870,7 +17892,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19148",
+          "$$hashKey": "object:17761",
           "checked": true,
           "visualize": "true"
         },
@@ -17881,7 +17903,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19149",
+          "$$hashKey": "object:17762",
           "checked": true,
           "visualize": "true"
         },
@@ -17892,7 +17914,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19150",
+          "$$hashKey": "object:17763",
           "checked": true,
           "visualize": "true"
         },
@@ -17903,7 +17925,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19151",
+          "$$hashKey": "object:17764",
           "checked": true,
           "visualize": "true"
         },
@@ -17914,7 +17936,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19152",
+          "$$hashKey": "object:17765",
           "checked": true,
           "visualize": "true"
         },
@@ -17925,7 +17947,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19153",
+          "$$hashKey": "object:17766",
           "checked": true,
           "visualize": "true"
         },
@@ -17936,7 +17958,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19154",
+          "$$hashKey": "object:17767",
           "checked": true,
           "visualize": "true"
         },
@@ -17947,7 +17969,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19155",
+          "$$hashKey": "object:17768",
           "checked": true,
           "visualize": "true"
         },
@@ -17958,7 +17980,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19156",
+          "$$hashKey": "object:17769",
           "checked": true,
           "visualize": "true"
         },
@@ -17969,7 +17991,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19157",
+          "$$hashKey": "object:17770",
           "checked": true,
           "visualize": "true"
         },
@@ -17980,7 +18002,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19158",
+          "$$hashKey": "object:17771",
           "checked": true,
           "visualize": "true"
         },
@@ -17991,7 +18013,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19159",
+          "$$hashKey": "object:17772",
           "checked": true,
           "visualize": "true"
         },
@@ -18002,7 +18024,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19160",
+          "$$hashKey": "object:17773",
           "checked": true,
           "visualize": "true"
         },
@@ -18013,7 +18035,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19161",
+          "$$hashKey": "object:17774",
           "checked": true,
           "visualize": "true"
         },
@@ -18024,7 +18046,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19162",
+          "$$hashKey": "object:17775",
           "checked": true,
           "visualize": "true"
         },
@@ -18035,7 +18057,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19163",
+          "$$hashKey": "object:17776",
           "checked": true,
           "visualize": "true"
         },
@@ -18046,7 +18068,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19164",
+          "$$hashKey": "object:17777",
           "checked": true,
           "visualize": "true"
         },
@@ -18057,7 +18079,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19165",
+          "$$hashKey": "object:17778",
           "checked": true,
           "visualize": "true"
         },
@@ -18068,7 +18090,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19166",
+          "$$hashKey": "object:17779",
           "checked": true,
           "visualize": "true"
         },
@@ -18079,7 +18101,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19167",
+          "$$hashKey": "object:17780",
           "checked": true,
           "visualize": "true"
         },
@@ -18090,7 +18112,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19168",
+          "$$hashKey": "object:17781",
           "checked": true,
           "visualize": "true"
         },
@@ -18101,7 +18123,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19169",
+          "$$hashKey": "object:17782",
           "checked": true,
           "visualize": "true"
         },
@@ -18112,7 +18134,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19170",
+          "$$hashKey": "object:17783",
           "checked": true,
           "visualize": "true"
         },
@@ -18123,7 +18145,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19171",
+          "$$hashKey": "object:17784",
           "checked": true,
           "visualize": "true"
         },
@@ -18134,7 +18156,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19172",
+          "$$hashKey": "object:17785",
           "checked": true,
           "visualize": "true"
         },
@@ -18145,7 +18167,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19173",
+          "$$hashKey": "object:17786",
           "checked": true,
           "visualize": "true"
         },
@@ -18156,7 +18178,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:19174",
+          "$$hashKey": "object:17787",
           "checked": true,
           "visualize": "true"
         }
@@ -18181,15 +18203,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "10/29/2019",
+      "date": "12/10/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.9861874756409668,
+      "instanceId": 0.9861345874356353,
       "skip": false,
-      "$$hashKey": "object:13668",
+      "$$hashKey": "object:14560",
       "outputMeasure": true,
       "userDefinedOutputs": [],
       "analysisOutputs": [
@@ -18200,7 +18222,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19070",
+          "$$hashKey": "object:17681",
           "checked": true,
           "visualize": "true"
         },
@@ -18211,7 +18233,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19071",
+          "$$hashKey": "object:17682",
           "checked": true,
           "visualize": "true"
         },
@@ -18222,7 +18244,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19072",
+          "$$hashKey": "object:17683",
           "checked": true,
           "visualize": "true"
         },
@@ -18233,7 +18255,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19073",
+          "$$hashKey": "object:17684",
           "checked": true,
           "visualize": "true"
         },
@@ -18244,7 +18266,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19074",
+          "$$hashKey": "object:17685",
           "checked": true,
           "visualize": "true"
         },
@@ -18255,7 +18277,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19075",
+          "$$hashKey": "object:17686",
           "checked": true,
           "visualize": "true"
         },
@@ -18266,7 +18288,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19076",
+          "$$hashKey": "object:17687",
           "checked": true,
           "visualize": "true"
         },
@@ -18277,7 +18299,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19077",
+          "$$hashKey": "object:17688",
           "checked": true,
           "visualize": "true"
         },
@@ -18288,7 +18310,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19078",
+          "$$hashKey": "object:17689",
           "checked": true,
           "visualize": "true"
         },
@@ -18299,7 +18321,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19079",
+          "$$hashKey": "object:17690",
           "checked": true,
           "visualize": "true"
         },
@@ -18310,7 +18332,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19080",
+          "$$hashKey": "object:17691",
           "checked": true,
           "visualize": "true"
         },
@@ -18321,7 +18343,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19081",
+          "$$hashKey": "object:17692",
           "checked": true,
           "visualize": "true"
         },
@@ -18332,7 +18354,29 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19082",
+          "$$hashKey": "object:17693",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_exterior_holiday_lighting_kwh",
+          "display_name": "electricity_exterior_holiday_lighting_kwh",
+          "short_name": "electricity_exterior_holiday_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:17694",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_garage_lighting_kwh",
+          "display_name": "electricity_garage_lighting_kwh",
+          "short_name": "electricity_garage_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:17695",
           "checked": true,
           "visualize": "true"
         },
@@ -18343,7 +18387,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19083",
+          "$$hashKey": "object:17696",
           "checked": true,
           "visualize": "true"
         },
@@ -18354,7 +18398,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19084",
+          "$$hashKey": "object:17697",
           "checked": true,
           "visualize": "true"
         },
@@ -18365,7 +18409,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19085",
+          "$$hashKey": "object:17698",
           "checked": true,
           "visualize": "true"
         },
@@ -18376,7 +18420,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19086",
+          "$$hashKey": "object:17699",
           "checked": true,
           "visualize": "true"
         },
@@ -18387,7 +18431,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19087",
+          "$$hashKey": "object:17700",
           "checked": true,
           "visualize": "true"
         },
@@ -18398,7 +18442,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19088",
+          "$$hashKey": "object:17701",
           "checked": true,
           "visualize": "true"
         },
@@ -18409,7 +18453,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19089",
+          "$$hashKey": "object:17702",
           "checked": true,
           "visualize": "true"
         },
@@ -18420,7 +18464,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19090",
+          "$$hashKey": "object:17703",
           "checked": true,
           "visualize": "true"
         },
@@ -18431,7 +18475,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19091",
+          "$$hashKey": "object:17704",
           "checked": true,
           "visualize": "true"
         },
@@ -18442,7 +18486,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19092",
+          "$$hashKey": "object:17705",
           "checked": true,
           "visualize": "true"
         },
@@ -18453,7 +18497,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19093",
+          "$$hashKey": "object:17706",
           "checked": true,
           "visualize": "true"
         },
@@ -18464,7 +18508,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19094",
+          "$$hashKey": "object:17707",
           "checked": true,
           "visualize": "true"
         },
@@ -18475,7 +18519,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19095",
+          "$$hashKey": "object:17708",
           "checked": true,
           "visualize": "true"
         },
@@ -18486,7 +18530,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19096",
+          "$$hashKey": "object:17709",
           "checked": true,
           "visualize": "true"
         },
@@ -18497,7 +18541,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19097",
+          "$$hashKey": "object:17710",
           "checked": true,
           "visualize": "true"
         },
@@ -18508,7 +18552,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19098",
+          "$$hashKey": "object:17711",
           "checked": true,
           "visualize": "true"
         },
@@ -18519,7 +18563,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19099",
+          "$$hashKey": "object:17712",
           "checked": true,
           "visualize": "true"
         },
@@ -18530,7 +18574,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19100",
+          "$$hashKey": "object:17713",
           "checked": true,
           "visualize": "true"
         },
@@ -18541,7 +18585,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19101",
+          "$$hashKey": "object:17714",
           "checked": true,
           "visualize": "true"
         },
@@ -18552,7 +18596,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19102",
+          "$$hashKey": "object:17715",
           "checked": true,
           "visualize": "true"
         },
@@ -18563,7 +18607,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19103",
+          "$$hashKey": "object:17716",
           "checked": true,
           "visualize": "true"
         },
@@ -18574,7 +18618,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19104",
+          "$$hashKey": "object:17717",
           "checked": true,
           "visualize": "true"
         },
@@ -18585,7 +18629,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19105",
+          "$$hashKey": "object:17718",
           "checked": true,
           "visualize": "true"
         },
@@ -18596,7 +18640,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19106",
+          "$$hashKey": "object:17719",
           "checked": true,
           "visualize": "true"
         },
@@ -18607,7 +18651,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19107",
+          "$$hashKey": "object:17720",
           "checked": true,
           "visualize": "true"
         },
@@ -18618,7 +18662,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19108",
+          "$$hashKey": "object:17721",
           "checked": true,
           "visualize": "true"
         },
@@ -18629,7 +18673,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19109",
+          "$$hashKey": "object:17722",
           "checked": true,
           "visualize": "true"
         },
@@ -18640,7 +18684,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19110",
+          "$$hashKey": "object:17723",
           "checked": true,
           "visualize": "true"
         },
@@ -18651,7 +18695,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19111",
+          "$$hashKey": "object:17724",
           "checked": true,
           "visualize": "true"
         },
@@ -18662,7 +18706,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19112",
+          "$$hashKey": "object:17725",
           "checked": true,
           "visualize": "true"
         },
@@ -18673,7 +18717,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19113",
+          "$$hashKey": "object:17726",
           "checked": true,
           "visualize": "true"
         },
@@ -18684,7 +18728,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19114",
+          "$$hashKey": "object:17727",
           "checked": true,
           "visualize": "true"
         },
@@ -18695,7 +18739,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19115",
+          "$$hashKey": "object:17728",
           "checked": true,
           "visualize": "true"
         },
@@ -18706,7 +18750,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19116",
+          "$$hashKey": "object:17729",
           "checked": true,
           "visualize": "true"
         },
@@ -18717,7 +18761,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19117",
+          "$$hashKey": "object:17730",
           "checked": true,
           "visualize": "true"
         },
@@ -18728,7 +18772,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19118",
+          "$$hashKey": "object:17731",
           "checked": true,
           "visualize": "true"
         },
@@ -18739,7 +18783,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19119",
+          "$$hashKey": "object:17732",
           "checked": true,
           "visualize": "true"
         },
@@ -18750,7 +18794,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19120",
+          "$$hashKey": "object:17733",
           "checked": true,
           "visualize": "true"
         },
@@ -18761,7 +18805,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19121",
+          "$$hashKey": "object:17734",
           "checked": true,
           "visualize": "true"
         },
@@ -18772,7 +18816,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19122",
+          "$$hashKey": "object:17735",
           "checked": true,
           "visualize": "true"
         },
@@ -18783,7 +18827,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19123",
+          "$$hashKey": "object:17736",
           "checked": true,
           "visualize": "true"
         },
@@ -18794,7 +18838,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19124",
+          "$$hashKey": "object:17737",
           "checked": true,
           "visualize": "true"
         },
@@ -18805,7 +18849,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19125",
+          "$$hashKey": "object:17738",
           "checked": true,
           "visualize": "true"
         },
@@ -18816,7 +18860,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19126",
+          "$$hashKey": "object:17739",
           "checked": true,
           "visualize": "true"
         },
@@ -18827,7 +18871,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19127",
+          "$$hashKey": "object:17740",
           "checked": true,
           "visualize": "true"
         },
@@ -18838,7 +18882,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19128",
+          "$$hashKey": "object:17741",
           "checked": true,
           "visualize": "true"
         },
@@ -18849,7 +18893,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19129",
+          "$$hashKey": "object:17742",
           "checked": true,
           "visualize": "true"
         },
@@ -18860,7 +18904,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19130",
+          "$$hashKey": "object:17743",
           "checked": true,
           "visualize": "true"
         },
@@ -18871,7 +18915,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19131",
+          "$$hashKey": "object:17744",
           "checked": true,
           "visualize": "true"
         },
@@ -18882,7 +18926,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19132",
+          "$$hashKey": "object:17745",
           "checked": true,
           "visualize": "true"
         },
@@ -18893,7 +18937,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19133",
+          "$$hashKey": "object:17746",
           "checked": true,
           "visualize": "true"
         },
@@ -18904,7 +18948,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19134",
+          "$$hashKey": "object:17747",
           "checked": true,
           "visualize": "true"
         },
@@ -18915,7 +18959,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19135",
+          "$$hashKey": "object:17748",
           "checked": true,
           "visualize": "true"
         },
@@ -18926,7 +18970,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19136",
+          "$$hashKey": "object:17749",
           "checked": true,
           "visualize": "true"
         },
@@ -18937,7 +18981,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19137",
+          "$$hashKey": "object:17750",
           "checked": true,
           "visualize": "true"
         },
@@ -18948,7 +18992,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19138",
+          "$$hashKey": "object:17751",
           "checked": true,
           "visualize": "true"
         },
@@ -18959,7 +19003,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19139",
+          "$$hashKey": "object:17752",
           "checked": true,
           "visualize": "true"
         },
@@ -18970,7 +19014,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19140",
+          "$$hashKey": "object:17753",
           "checked": true,
           "visualize": "true"
         },
@@ -18981,7 +19025,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19141",
+          "$$hashKey": "object:17754",
           "checked": true,
           "visualize": "true"
         },
@@ -18992,7 +19036,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19142",
+          "$$hashKey": "object:17755",
           "checked": true,
           "visualize": "true"
         },
@@ -19003,7 +19047,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19143",
+          "$$hashKey": "object:17756",
           "checked": true,
           "visualize": "true"
         },
@@ -19014,7 +19058,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19144",
+          "$$hashKey": "object:17757",
           "checked": true,
           "visualize": "true"
         },
@@ -19025,7 +19069,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19145",
+          "$$hashKey": "object:17758",
           "checked": true,
           "visualize": "true"
         },
@@ -19036,7 +19080,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19146",
+          "$$hashKey": "object:17759",
           "checked": true,
           "visualize": "true"
         },
@@ -19047,7 +19091,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19147",
+          "$$hashKey": "object:17760",
           "checked": true,
           "visualize": "true"
         },
@@ -19058,7 +19102,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19148",
+          "$$hashKey": "object:17761",
           "checked": true,
           "visualize": "true"
         },
@@ -19069,7 +19113,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19149",
+          "$$hashKey": "object:17762",
           "checked": true,
           "visualize": "true"
         },
@@ -19080,7 +19124,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19150",
+          "$$hashKey": "object:17763",
           "checked": true,
           "visualize": "true"
         },
@@ -19091,7 +19135,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19151",
+          "$$hashKey": "object:17764",
           "checked": true,
           "visualize": "true"
         },
@@ -19102,7 +19146,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19152",
+          "$$hashKey": "object:17765",
           "checked": true,
           "visualize": "true"
         },
@@ -19113,7 +19157,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19153",
+          "$$hashKey": "object:17766",
           "checked": true,
           "visualize": "true"
         },
@@ -19124,7 +19168,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19154",
+          "$$hashKey": "object:17767",
           "checked": true,
           "visualize": "true"
         },
@@ -19135,7 +19179,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19155",
+          "$$hashKey": "object:17768",
           "checked": true,
           "visualize": "true"
         },
@@ -19146,7 +19190,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19156",
+          "$$hashKey": "object:17769",
           "checked": true,
           "visualize": "true"
         },
@@ -19157,7 +19201,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19157",
+          "$$hashKey": "object:17770",
           "checked": true,
           "visualize": "true"
         },
@@ -19168,7 +19212,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19158",
+          "$$hashKey": "object:17771",
           "checked": true,
           "visualize": "true"
         },
@@ -19179,7 +19223,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19159",
+          "$$hashKey": "object:17772",
           "checked": true,
           "visualize": "true"
         },
@@ -19190,7 +19234,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19160",
+          "$$hashKey": "object:17773",
           "checked": true,
           "visualize": "true"
         },
@@ -19201,7 +19245,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19161",
+          "$$hashKey": "object:17774",
           "checked": true,
           "visualize": "true"
         },
@@ -19212,7 +19256,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19162",
+          "$$hashKey": "object:17775",
           "checked": true,
           "visualize": "true"
         },
@@ -19223,7 +19267,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19163",
+          "$$hashKey": "object:17776",
           "checked": true,
           "visualize": "true"
         },
@@ -19234,7 +19278,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19164",
+          "$$hashKey": "object:17777",
           "checked": true,
           "visualize": "true"
         },
@@ -19245,7 +19289,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19165",
+          "$$hashKey": "object:17778",
           "checked": true,
           "visualize": "true"
         },
@@ -19256,7 +19300,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19166",
+          "$$hashKey": "object:17779",
           "checked": true,
           "visualize": "true"
         },
@@ -19267,7 +19311,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19167",
+          "$$hashKey": "object:17780",
           "checked": true,
           "visualize": "true"
         },
@@ -19278,7 +19322,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19168",
+          "$$hashKey": "object:17781",
           "checked": true,
           "visualize": "true"
         },
@@ -19289,7 +19333,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19169",
+          "$$hashKey": "object:17782",
           "checked": true,
           "visualize": "true"
         },
@@ -19300,7 +19344,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19170",
+          "$$hashKey": "object:17783",
           "checked": true,
           "visualize": "true"
         },
@@ -19311,7 +19355,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19171",
+          "$$hashKey": "object:17784",
           "checked": true,
           "visualize": "true"
         },
@@ -19322,7 +19366,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19172",
+          "$$hashKey": "object:17785",
           "checked": true,
           "visualize": "true"
         },
@@ -19333,7 +19377,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19173",
+          "$$hashKey": "object:17786",
           "checked": true,
           "visualize": "true"
         },
@@ -19344,7 +19388,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:19174",
+          "$$hashKey": "object:17787",
           "checked": true,
           "visualize": "true"
         }
@@ -19356,9 +19400,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/TimeseriesCSVExport",
       "uid": "2a3442c1-944d-4e91-9e11-11e0cf368c64",
       "uuid": "{2a3442c1-944d-4e91-9e11-11e0cf368c64}",
-      "version_id": "7d687785-9dfb-47b6-84c1-3775bd638174",
-      "version_uuid": "{7d687785-9dfb-47b6-84c1-3775bd638174}",
-      "version_modified": "20191029T154255Z",
+      "version_id": "64696f29-6d80-4418-b20d-61f5bdff5495",
+      "version_uuid": "{64696f29-6d80-4418-b20d-61f5bdff5495}",
+      "version_modified": "20191210T220251Z",
       "xml_checksum": "15BF4E57",
       "display_name": "Timeseries CSV Export",
       "class_name": "TimeseriesCSVExport",
@@ -19413,7 +19457,7 @@
             "stdDev": "Hourly",
             "default_value": "Hourly"
           },
-          "$$hashKey": "object:13802"
+          "$$hashKey": "object:34202"
         },
         {
           "name": "include_enduse_subcategories",
@@ -19437,7 +19481,7 @@
             "stdDev": false,
             "default_value": false
           },
-          "$$hashKey": "object:13803"
+          "$$hashKey": "object:34203"
         },
         {
           "name": "output_variables",
@@ -19460,7 +19504,7 @@
             "stdDev": "",
             "default_value": ""
           },
-          "$$hashKey": "object:13804"
+          "$$hashKey": "object:34204"
         }
       ],
       "edit": "",
@@ -19470,16 +19514,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "10/29/2019",
+      "date": "12/10/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.5250900117667501,
+      "instanceId": 0.426874375420923,
       "skip": false,
-      "$$hashKey": "object:13669",
-      "outputMeasure": false
+      "$$hashKey": "object:34159"
     },
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\ServerDirectoryCleanup",
@@ -19523,7 +19566,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.13355629599468455,
+      "instanceId": 0.2981040360280336,
       "skip": false,
       "$$hashKey": "object:663249",
       "outputMeasure": false

--- a/project_singlefamilydetached/measures/SimulationOutputReport/measure.rb
+++ b/project_singlefamilydetached/measures/SimulationOutputReport/measure.rb
@@ -74,6 +74,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "electricity_central_system_cooling_kwh",
       "electricity_interior_lighting_kwh",
       "electricity_exterior_lighting_kwh",
+      "electricity_exterior_holiday_lighting_kwh",
+      "electricity_garage_lighting_kwh",
       "electricity_interior_equipment_kwh",
       "electricity_fans_heating_kwh",
       "electricity_fans_cooling_kwh",
@@ -193,7 +195,6 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # ELECTRICITY
 
-    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "total_site_electricity_kwh", electricity.total_end_uses[0], "GJ", elec_site_units)
     report_sim_output(runner, "net_site_electricity_kwh", electricity.total_end_uses[0] - electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_heating_kwh", electricity.heating[0], "GJ", elec_site_units)
@@ -202,8 +203,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_cooling_kwh", electricity.central_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_lighting_kwh", electricity.interior_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_exterior_lighting_kwh", electricity.exterior_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_garage_lighting_kwh", electricity.garage_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_equipment_kwh", electricity.interior_equipment[0], "GJ", elec_site_units)
-    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
 
     # Initialize variables to check against sql file totals
     env_period_ix_query = "SELECT EnvironmentPeriodIndex FROM EnvironmentPeriods WHERE EnvironmentName='#{ann_env_pd}'"
@@ -261,6 +263,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_pumps_heating_kwh", electricity.central_pumps_heating[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_pumps_cooling_kwh", electricity.pumps_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_central_system_pumps_cooling_kwh", electricity.central_pumps_cooling[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
 
     # NATURAL GAS
 

--- a/project_singlefamilydetached/measures/SimulationOutputReport/measure.xml
+++ b/project_singlefamilydetached/measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>a76e6c10-23a1-4159-b3a3-693195d53895</version_id>
-  <version_modified>20191029T171022Z</version_modified>
+  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
@@ -99,6 +99,20 @@
       <name>electricity_exterior_lighting_kwh</name>
       <display_name>electricity_exterior_lighting_kwh</display_name>
       <short_name>electricity_exterior_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_exterior_holiday_lighting_kwh</name>
+      <display_name>electricity_exterior_holiday_lighting_kwh</display_name>
+      <short_name>electricity_exterior_holiday_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_garage_lighting_kwh</name>
+      <display_name>electricity_garage_lighting_kwh</display_name>
+      <short_name>electricity_garage_lighting_kwh</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -779,7 +793,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9C639C14</checksum>
+      <checksum>0EBF3BC0</checksum>
     </file>
   </files>
 </measure>

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.rb
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.rb
@@ -203,6 +203,8 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "electricity_central_system_cooling_kwh", electricity.central_cooling, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_lighting_kwh", electricity.interior_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_exterior_lighting_kwh", electricity.exterior_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_equipment_kwh", electricity.interior_equipment, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_heating_kwh", electricity.fans_heating, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_cooling_kwh", electricity.fans_cooling, "GJ", elec_site_units)
@@ -276,8 +278,6 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
       report_ts_output(runner, timeseries, "natural_gas_lighting_therm", natural_gas.lighting, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "natural_gas_fireplace_therm", natural_gas.fireplace, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "electricity_well_pump_kwh", electricity.well_pump, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
     end
 
     output_vars.each do |output_var|

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.xml
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>7d687785-9dfb-47b6-84c1-3775bd638174</version_id>
-  <version_modified>20191029T154255Z</version_modified>
+  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,12 +79,6 @@
   </attributes>
   <files>
     <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>B94D34E1</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -93,7 +87,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E2397EB2</checksum>
+      <checksum>6C92E878</checksum>
+    </file>
+    <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F8C982FF</checksum>
     </file>
   </files>
 </measure>

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_singlefamilydetached/pat.json
+++ b/project_singlefamilydetached/pat.json
@@ -312,7 +312,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.8245888034532145,
+      "instanceId": 0.7851535532199383,
       "skip": false,
       "$$hashKey": "object:11247",
       "outputMeasure": false
@@ -494,7 +494,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.19074545085542582,
+      "instanceId": 0.40823157597298243,
       "skip": false,
       "$$hashKey": "object:34632",
       "showWarningText": false,
@@ -7316,7 +7316,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.5683559522674739,
+      "instanceId": 0.3778964561583489,
       "skip": false,
       "$$hashKey": "object:34633",
       "showWarningText": false,
@@ -14138,7 +14138,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.3189001018209616,
+      "instanceId": 0.8637729718864875,
       "skip": false,
       "$$hashKey": "object:40798",
       "showWarningText": false,
@@ -14147,7 +14147,7 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildingCharacteristicsReport",
       "name": "building_characteristics_report",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
       "version_id": "96e57a64-ab28-49aa-87de-41cb2c1f3c15",
@@ -15584,7 +15584,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.11740294369762472,
+      "instanceId": 0.5216424192043945,
       "skip": false,
       "$$hashKey": "object:14901",
       "outputMeasure": true,
@@ -16995,9 +16995,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/SimulationOutputReport",
       "uid": "fc337100-8634-404e-8966-01243d292a79",
       "uuid": "{fc337100-8634-404e-8966-01243d292a79}",
-      "version_id": "a76e6c10-23a1-4159-b3a3-693195d53895",
-      "version_uuid": "{a76e6c10-23a1-4159-b3a3-693195d53895}",
-      "version_modified": "20191029T171022Z",
+      "version_id": "452c3c75-928b-4c49-93f5-dc319088b009",
+      "version_uuid": "{452c3c75-928b-4c49-93f5-dc319088b009}",
+      "version_modified": "20191210T220251Z",
       "xml_checksum": "2C8A3EEF",
       "display_name": "Simulation Output Report",
       "class_name": "SimulationOutputReport",
@@ -17012,7 +17012,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19079",
+          "$$hashKey": "object:18041",
           "checked": true,
           "visualize": "true"
         },
@@ -17023,7 +17023,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19080",
+          "$$hashKey": "object:18042",
           "checked": true,
           "visualize": "true"
         },
@@ -17034,7 +17034,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19081",
+          "$$hashKey": "object:18043",
           "checked": true,
           "visualize": "true"
         },
@@ -17045,7 +17045,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19082",
+          "$$hashKey": "object:18044",
           "checked": true,
           "visualize": "true"
         },
@@ -17056,7 +17056,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19083",
+          "$$hashKey": "object:18045",
           "checked": true,
           "visualize": "true"
         },
@@ -17067,7 +17067,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19084",
+          "$$hashKey": "object:18046",
           "checked": true,
           "visualize": "true"
         },
@@ -17078,7 +17078,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19085",
+          "$$hashKey": "object:18047",
           "checked": true,
           "visualize": "true"
         },
@@ -17089,7 +17089,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19086",
+          "$$hashKey": "object:18048",
           "checked": true,
           "visualize": "true"
         },
@@ -17100,7 +17100,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19087",
+          "$$hashKey": "object:18049",
           "checked": true,
           "visualize": "true"
         },
@@ -17111,7 +17111,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19088",
+          "$$hashKey": "object:18050",
           "checked": true,
           "visualize": "true"
         },
@@ -17122,7 +17122,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19089",
+          "$$hashKey": "object:18051",
           "checked": true,
           "visualize": "true"
         },
@@ -17133,7 +17133,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19090",
+          "$$hashKey": "object:18052",
           "checked": true,
           "visualize": "true"
         },
@@ -17144,7 +17144,29 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19091",
+          "$$hashKey": "object:18053",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_exterior_holiday_lighting_kwh",
+          "display_name": "electricity_exterior_holiday_lighting_kwh",
+          "short_name": "electricity_exterior_holiday_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:18054",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_garage_lighting_kwh",
+          "display_name": "electricity_garage_lighting_kwh",
+          "short_name": "electricity_garage_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:18055",
           "checked": true,
           "visualize": "true"
         },
@@ -17155,7 +17177,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19092",
+          "$$hashKey": "object:18056",
           "checked": true,
           "visualize": "true"
         },
@@ -17166,7 +17188,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19093",
+          "$$hashKey": "object:18057",
           "checked": true,
           "visualize": "true"
         },
@@ -17177,7 +17199,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19094",
+          "$$hashKey": "object:18058",
           "checked": true,
           "visualize": "true"
         },
@@ -17188,7 +17210,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19095",
+          "$$hashKey": "object:18059",
           "checked": true,
           "visualize": "true"
         },
@@ -17199,7 +17221,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19096",
+          "$$hashKey": "object:18060",
           "checked": true,
           "visualize": "true"
         },
@@ -17210,7 +17232,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19097",
+          "$$hashKey": "object:18061",
           "checked": true,
           "visualize": "true"
         },
@@ -17221,7 +17243,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19098",
+          "$$hashKey": "object:18062",
           "checked": true,
           "visualize": "true"
         },
@@ -17232,7 +17254,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19099",
+          "$$hashKey": "object:18063",
           "checked": true,
           "visualize": "true"
         },
@@ -17243,7 +17265,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19100",
+          "$$hashKey": "object:18064",
           "checked": true,
           "visualize": "true"
         },
@@ -17254,7 +17276,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19101",
+          "$$hashKey": "object:18065",
           "checked": true,
           "visualize": "true"
         },
@@ -17265,7 +17287,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19102",
+          "$$hashKey": "object:18066",
           "checked": true,
           "visualize": "true"
         },
@@ -17276,7 +17298,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19103",
+          "$$hashKey": "object:18067",
           "checked": true,
           "visualize": "true"
         },
@@ -17287,7 +17309,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19104",
+          "$$hashKey": "object:18068",
           "checked": true,
           "visualize": "true"
         },
@@ -17298,7 +17320,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19105",
+          "$$hashKey": "object:18069",
           "checked": true,
           "visualize": "true"
         },
@@ -17309,7 +17331,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19106",
+          "$$hashKey": "object:18070",
           "checked": true,
           "visualize": "true"
         },
@@ -17320,7 +17342,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19107",
+          "$$hashKey": "object:18071",
           "checked": true,
           "visualize": "true"
         },
@@ -17331,7 +17353,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19108",
+          "$$hashKey": "object:18072",
           "checked": true,
           "visualize": "true"
         },
@@ -17342,7 +17364,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19109",
+          "$$hashKey": "object:18073",
           "checked": true,
           "visualize": "true"
         },
@@ -17353,7 +17375,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19110",
+          "$$hashKey": "object:18074",
           "checked": true,
           "visualize": "true"
         },
@@ -17364,7 +17386,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19111",
+          "$$hashKey": "object:18075",
           "checked": true,
           "visualize": "true"
         },
@@ -17375,7 +17397,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19112",
+          "$$hashKey": "object:18076",
           "checked": true,
           "visualize": "true"
         },
@@ -17386,7 +17408,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19113",
+          "$$hashKey": "object:18077",
           "checked": true,
           "visualize": "true"
         },
@@ -17397,7 +17419,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19114",
+          "$$hashKey": "object:18078",
           "checked": true,
           "visualize": "true"
         },
@@ -17408,7 +17430,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19115",
+          "$$hashKey": "object:18079",
           "checked": true,
           "visualize": "true"
         },
@@ -17419,7 +17441,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19116",
+          "$$hashKey": "object:18080",
           "checked": true,
           "visualize": "true"
         },
@@ -17430,7 +17452,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19117",
+          "$$hashKey": "object:18081",
           "checked": true,
           "visualize": "true"
         },
@@ -17441,7 +17463,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19118",
+          "$$hashKey": "object:18082",
           "checked": true,
           "visualize": "true"
         },
@@ -17452,7 +17474,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19119",
+          "$$hashKey": "object:18083",
           "checked": true,
           "visualize": "true"
         },
@@ -17463,7 +17485,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19120",
+          "$$hashKey": "object:18084",
           "checked": true,
           "visualize": "true"
         },
@@ -17474,7 +17496,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19121",
+          "$$hashKey": "object:18085",
           "checked": true,
           "visualize": "true"
         },
@@ -17485,7 +17507,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19122",
+          "$$hashKey": "object:18086",
           "checked": true,
           "visualize": "true"
         },
@@ -17496,7 +17518,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19123",
+          "$$hashKey": "object:18087",
           "checked": true,
           "visualize": "true"
         },
@@ -17507,7 +17529,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19124",
+          "$$hashKey": "object:18088",
           "checked": true,
           "visualize": "true"
         },
@@ -17518,7 +17540,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19125",
+          "$$hashKey": "object:18089",
           "checked": true,
           "visualize": "true"
         },
@@ -17529,7 +17551,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19126",
+          "$$hashKey": "object:18090",
           "checked": true,
           "visualize": "true"
         },
@@ -17540,7 +17562,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19127",
+          "$$hashKey": "object:18091",
           "checked": true,
           "visualize": "true"
         },
@@ -17551,7 +17573,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19128",
+          "$$hashKey": "object:18092",
           "checked": true,
           "visualize": "true"
         },
@@ -17562,7 +17584,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19129",
+          "$$hashKey": "object:18093",
           "checked": true,
           "visualize": "true"
         },
@@ -17573,7 +17595,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19130",
+          "$$hashKey": "object:18094",
           "checked": true,
           "visualize": "true"
         },
@@ -17584,7 +17606,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19131",
+          "$$hashKey": "object:18095",
           "checked": true,
           "visualize": "true"
         },
@@ -17595,7 +17617,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19132",
+          "$$hashKey": "object:18096",
           "checked": true,
           "visualize": "true"
         },
@@ -17606,7 +17628,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19133",
+          "$$hashKey": "object:18097",
           "checked": true,
           "visualize": "true"
         },
@@ -17617,7 +17639,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19134",
+          "$$hashKey": "object:18098",
           "checked": true,
           "visualize": "true"
         },
@@ -17628,7 +17650,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19135",
+          "$$hashKey": "object:18099",
           "checked": true,
           "visualize": "true"
         },
@@ -17639,7 +17661,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19136",
+          "$$hashKey": "object:18100",
           "checked": true,
           "visualize": "true"
         },
@@ -17650,7 +17672,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19137",
+          "$$hashKey": "object:18101",
           "checked": true,
           "visualize": "true"
         },
@@ -17661,7 +17683,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19138",
+          "$$hashKey": "object:18102",
           "checked": true,
           "visualize": "true"
         },
@@ -17672,7 +17694,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19139",
+          "$$hashKey": "object:18103",
           "checked": true,
           "visualize": "true"
         },
@@ -17683,7 +17705,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19140",
+          "$$hashKey": "object:18104",
           "checked": true,
           "visualize": "true"
         },
@@ -17694,7 +17716,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19141",
+          "$$hashKey": "object:18105",
           "checked": true,
           "visualize": "true"
         },
@@ -17705,7 +17727,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19142",
+          "$$hashKey": "object:18106",
           "checked": true,
           "visualize": "true"
         },
@@ -17716,7 +17738,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19143",
+          "$$hashKey": "object:18107",
           "checked": true,
           "visualize": "true"
         },
@@ -17727,7 +17749,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19144",
+          "$$hashKey": "object:18108",
           "checked": true,
           "visualize": "true"
         },
@@ -17738,7 +17760,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19145",
+          "$$hashKey": "object:18109",
           "checked": true,
           "visualize": "true"
         },
@@ -17749,7 +17771,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19146",
+          "$$hashKey": "object:18110",
           "checked": true,
           "visualize": "true"
         },
@@ -17760,7 +17782,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19147",
+          "$$hashKey": "object:18111",
           "checked": true,
           "visualize": "true"
         },
@@ -17771,7 +17793,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19148",
+          "$$hashKey": "object:18112",
           "checked": true,
           "visualize": "true"
         },
@@ -17782,7 +17804,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19149",
+          "$$hashKey": "object:18113",
           "checked": true,
           "visualize": "true"
         },
@@ -17793,7 +17815,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19150",
+          "$$hashKey": "object:18114",
           "checked": true,
           "visualize": "true"
         },
@@ -17804,7 +17826,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19151",
+          "$$hashKey": "object:18115",
           "checked": true,
           "visualize": "true"
         },
@@ -17815,7 +17837,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19152",
+          "$$hashKey": "object:18116",
           "checked": true,
           "visualize": "true"
         },
@@ -17826,7 +17848,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19153",
+          "$$hashKey": "object:18117",
           "checked": true,
           "visualize": "true"
         },
@@ -17837,7 +17859,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19154",
+          "$$hashKey": "object:18118",
           "checked": true,
           "visualize": "true"
         },
@@ -17848,7 +17870,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19155",
+          "$$hashKey": "object:18119",
           "checked": true,
           "visualize": "true"
         },
@@ -17859,7 +17881,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19156",
+          "$$hashKey": "object:18120",
           "checked": true,
           "visualize": "true"
         },
@@ -17870,7 +17892,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19157",
+          "$$hashKey": "object:18121",
           "checked": true,
           "visualize": "true"
         },
@@ -17881,7 +17903,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19158",
+          "$$hashKey": "object:18122",
           "checked": true,
           "visualize": "true"
         },
@@ -17892,7 +17914,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19159",
+          "$$hashKey": "object:18123",
           "checked": true,
           "visualize": "true"
         },
@@ -17903,7 +17925,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19160",
+          "$$hashKey": "object:18124",
           "checked": true,
           "visualize": "true"
         },
@@ -17914,7 +17936,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19161",
+          "$$hashKey": "object:18125",
           "checked": true,
           "visualize": "true"
         },
@@ -17925,7 +17947,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19162",
+          "$$hashKey": "object:18126",
           "checked": true,
           "visualize": "true"
         },
@@ -17936,7 +17958,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19163",
+          "$$hashKey": "object:18127",
           "checked": true,
           "visualize": "true"
         },
@@ -17947,7 +17969,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19164",
+          "$$hashKey": "object:18128",
           "checked": true,
           "visualize": "true"
         },
@@ -17958,7 +17980,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19165",
+          "$$hashKey": "object:18129",
           "checked": true,
           "visualize": "true"
         },
@@ -17969,7 +17991,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19166",
+          "$$hashKey": "object:18130",
           "checked": true,
           "visualize": "true"
         },
@@ -17980,7 +18002,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19167",
+          "$$hashKey": "object:18131",
           "checked": true,
           "visualize": "true"
         },
@@ -17991,7 +18013,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19168",
+          "$$hashKey": "object:18132",
           "checked": true,
           "visualize": "true"
         },
@@ -18002,7 +18024,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19169",
+          "$$hashKey": "object:18133",
           "checked": true,
           "visualize": "true"
         },
@@ -18013,7 +18035,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19170",
+          "$$hashKey": "object:18134",
           "checked": true,
           "visualize": "true"
         },
@@ -18024,7 +18046,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19171",
+          "$$hashKey": "object:18135",
           "checked": true,
           "visualize": "true"
         },
@@ -18035,7 +18057,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19172",
+          "$$hashKey": "object:18136",
           "checked": true,
           "visualize": "true"
         },
@@ -18046,7 +18068,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19173",
+          "$$hashKey": "object:18137",
           "checked": true,
           "visualize": "true"
         },
@@ -18057,7 +18079,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19174",
+          "$$hashKey": "object:18138",
           "checked": true,
           "visualize": "true"
         },
@@ -18068,7 +18090,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19175",
+          "$$hashKey": "object:18139",
           "checked": true,
           "visualize": "true"
         },
@@ -18079,7 +18101,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19176",
+          "$$hashKey": "object:18140",
           "checked": true,
           "visualize": "true"
         },
@@ -18090,7 +18112,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19177",
+          "$$hashKey": "object:18141",
           "checked": true,
           "visualize": "true"
         },
@@ -18101,7 +18123,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19178",
+          "$$hashKey": "object:18142",
           "checked": true,
           "visualize": "true"
         },
@@ -18112,7 +18134,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19179",
+          "$$hashKey": "object:18143",
           "checked": true,
           "visualize": "true"
         },
@@ -18123,7 +18145,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19180",
+          "$$hashKey": "object:18144",
           "checked": true,
           "visualize": "true"
         },
@@ -18134,7 +18156,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19181",
+          "$$hashKey": "object:18145",
           "checked": true,
           "visualize": "true"
         },
@@ -18145,7 +18167,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19182",
+          "$$hashKey": "object:18146",
           "checked": true,
           "visualize": "true"
         },
@@ -18156,7 +18178,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:19183",
+          "$$hashKey": "object:18147",
           "checked": true,
           "visualize": "true"
         }
@@ -18181,15 +18203,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "10/29/2019",
+      "date": "12/10/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.7880647285803253,
+      "instanceId": 0.7727461950623025,
       "skip": false,
-      "$$hashKey": "object:13669",
+      "$$hashKey": "object:13588",
       "outputMeasure": true,
       "userDefinedOutputs": [],
       "analysisOutputs": [
@@ -18200,7 +18222,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19079",
+          "$$hashKey": "object:18041",
           "checked": true,
           "visualize": "true"
         },
@@ -18211,7 +18233,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19080",
+          "$$hashKey": "object:18042",
           "checked": true,
           "visualize": "true"
         },
@@ -18222,7 +18244,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19081",
+          "$$hashKey": "object:18043",
           "checked": true,
           "visualize": "true"
         },
@@ -18233,7 +18255,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19082",
+          "$$hashKey": "object:18044",
           "checked": true,
           "visualize": "true"
         },
@@ -18244,7 +18266,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19083",
+          "$$hashKey": "object:18045",
           "checked": true,
           "visualize": "true"
         },
@@ -18255,7 +18277,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19084",
+          "$$hashKey": "object:18046",
           "checked": true,
           "visualize": "true"
         },
@@ -18266,7 +18288,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19085",
+          "$$hashKey": "object:18047",
           "checked": true,
           "visualize": "true"
         },
@@ -18277,7 +18299,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19086",
+          "$$hashKey": "object:18048",
           "checked": true,
           "visualize": "true"
         },
@@ -18288,7 +18310,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19087",
+          "$$hashKey": "object:18049",
           "checked": true,
           "visualize": "true"
         },
@@ -18299,7 +18321,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19088",
+          "$$hashKey": "object:18050",
           "checked": true,
           "visualize": "true"
         },
@@ -18310,7 +18332,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19089",
+          "$$hashKey": "object:18051",
           "checked": true,
           "visualize": "true"
         },
@@ -18321,7 +18343,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19090",
+          "$$hashKey": "object:18052",
           "checked": true,
           "visualize": "true"
         },
@@ -18332,7 +18354,29 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19091",
+          "$$hashKey": "object:18053",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_exterior_holiday_lighting_kwh",
+          "display_name": "electricity_exterior_holiday_lighting_kwh",
+          "short_name": "electricity_exterior_holiday_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:18054",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "electricity_garage_lighting_kwh",
+          "display_name": "electricity_garage_lighting_kwh",
+          "short_name": "electricity_garage_lighting_kwh",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:18055",
           "checked": true,
           "visualize": "true"
         },
@@ -18343,7 +18387,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19092",
+          "$$hashKey": "object:18056",
           "checked": true,
           "visualize": "true"
         },
@@ -18354,7 +18398,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19093",
+          "$$hashKey": "object:18057",
           "checked": true,
           "visualize": "true"
         },
@@ -18365,7 +18409,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19094",
+          "$$hashKey": "object:18058",
           "checked": true,
           "visualize": "true"
         },
@@ -18376,7 +18420,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19095",
+          "$$hashKey": "object:18059",
           "checked": true,
           "visualize": "true"
         },
@@ -18387,7 +18431,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19096",
+          "$$hashKey": "object:18060",
           "checked": true,
           "visualize": "true"
         },
@@ -18398,7 +18442,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19097",
+          "$$hashKey": "object:18061",
           "checked": true,
           "visualize": "true"
         },
@@ -18409,7 +18453,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19098",
+          "$$hashKey": "object:18062",
           "checked": true,
           "visualize": "true"
         },
@@ -18420,7 +18464,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19099",
+          "$$hashKey": "object:18063",
           "checked": true,
           "visualize": "true"
         },
@@ -18431,7 +18475,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19100",
+          "$$hashKey": "object:18064",
           "checked": true,
           "visualize": "true"
         },
@@ -18442,7 +18486,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19101",
+          "$$hashKey": "object:18065",
           "checked": true,
           "visualize": "true"
         },
@@ -18453,7 +18497,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19102",
+          "$$hashKey": "object:18066",
           "checked": true,
           "visualize": "true"
         },
@@ -18464,7 +18508,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19103",
+          "$$hashKey": "object:18067",
           "checked": true,
           "visualize": "true"
         },
@@ -18475,7 +18519,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19104",
+          "$$hashKey": "object:18068",
           "checked": true,
           "visualize": "true"
         },
@@ -18486,7 +18530,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19105",
+          "$$hashKey": "object:18069",
           "checked": true,
           "visualize": "true"
         },
@@ -18497,7 +18541,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19106",
+          "$$hashKey": "object:18070",
           "checked": true,
           "visualize": "true"
         },
@@ -18508,7 +18552,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19107",
+          "$$hashKey": "object:18071",
           "checked": true,
           "visualize": "true"
         },
@@ -18519,7 +18563,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19108",
+          "$$hashKey": "object:18072",
           "checked": true,
           "visualize": "true"
         },
@@ -18530,7 +18574,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19109",
+          "$$hashKey": "object:18073",
           "checked": true,
           "visualize": "true"
         },
@@ -18541,7 +18585,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19110",
+          "$$hashKey": "object:18074",
           "checked": true,
           "visualize": "true"
         },
@@ -18552,7 +18596,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19111",
+          "$$hashKey": "object:18075",
           "checked": true,
           "visualize": "true"
         },
@@ -18563,7 +18607,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19112",
+          "$$hashKey": "object:18076",
           "checked": true,
           "visualize": "true"
         },
@@ -18574,7 +18618,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19113",
+          "$$hashKey": "object:18077",
           "checked": true,
           "visualize": "true"
         },
@@ -18585,7 +18629,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19114",
+          "$$hashKey": "object:18078",
           "checked": true,
           "visualize": "true"
         },
@@ -18596,7 +18640,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19115",
+          "$$hashKey": "object:18079",
           "checked": true,
           "visualize": "true"
         },
@@ -18607,7 +18651,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19116",
+          "$$hashKey": "object:18080",
           "checked": true,
           "visualize": "true"
         },
@@ -18618,7 +18662,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19117",
+          "$$hashKey": "object:18081",
           "checked": true,
           "visualize": "true"
         },
@@ -18629,7 +18673,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19118",
+          "$$hashKey": "object:18082",
           "checked": true,
           "visualize": "true"
         },
@@ -18640,7 +18684,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19119",
+          "$$hashKey": "object:18083",
           "checked": true,
           "visualize": "true"
         },
@@ -18651,7 +18695,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19120",
+          "$$hashKey": "object:18084",
           "checked": true,
           "visualize": "true"
         },
@@ -18662,7 +18706,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19121",
+          "$$hashKey": "object:18085",
           "checked": true,
           "visualize": "true"
         },
@@ -18673,7 +18717,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19122",
+          "$$hashKey": "object:18086",
           "checked": true,
           "visualize": "true"
         },
@@ -18684,7 +18728,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19123",
+          "$$hashKey": "object:18087",
           "checked": true,
           "visualize": "true"
         },
@@ -18695,7 +18739,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19124",
+          "$$hashKey": "object:18088",
           "checked": true,
           "visualize": "true"
         },
@@ -18706,7 +18750,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19125",
+          "$$hashKey": "object:18089",
           "checked": true,
           "visualize": "true"
         },
@@ -18717,7 +18761,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19126",
+          "$$hashKey": "object:18090",
           "checked": true,
           "visualize": "true"
         },
@@ -18728,7 +18772,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19127",
+          "$$hashKey": "object:18091",
           "checked": true,
           "visualize": "true"
         },
@@ -18739,7 +18783,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19128",
+          "$$hashKey": "object:18092",
           "checked": true,
           "visualize": "true"
         },
@@ -18750,7 +18794,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19129",
+          "$$hashKey": "object:18093",
           "checked": true,
           "visualize": "true"
         },
@@ -18761,7 +18805,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19130",
+          "$$hashKey": "object:18094",
           "checked": true,
           "visualize": "true"
         },
@@ -18772,7 +18816,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19131",
+          "$$hashKey": "object:18095",
           "checked": true,
           "visualize": "true"
         },
@@ -18783,7 +18827,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19132",
+          "$$hashKey": "object:18096",
           "checked": true,
           "visualize": "true"
         },
@@ -18794,7 +18838,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19133",
+          "$$hashKey": "object:18097",
           "checked": true,
           "visualize": "true"
         },
@@ -18805,7 +18849,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19134",
+          "$$hashKey": "object:18098",
           "checked": true,
           "visualize": "true"
         },
@@ -18816,7 +18860,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19135",
+          "$$hashKey": "object:18099",
           "checked": true,
           "visualize": "true"
         },
@@ -18827,7 +18871,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19136",
+          "$$hashKey": "object:18100",
           "checked": true,
           "visualize": "true"
         },
@@ -18838,7 +18882,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19137",
+          "$$hashKey": "object:18101",
           "checked": true,
           "visualize": "true"
         },
@@ -18849,7 +18893,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19138",
+          "$$hashKey": "object:18102",
           "checked": true,
           "visualize": "true"
         },
@@ -18860,7 +18904,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19139",
+          "$$hashKey": "object:18103",
           "checked": true,
           "visualize": "true"
         },
@@ -18871,7 +18915,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19140",
+          "$$hashKey": "object:18104",
           "checked": true,
           "visualize": "true"
         },
@@ -18882,7 +18926,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19141",
+          "$$hashKey": "object:18105",
           "checked": true,
           "visualize": "true"
         },
@@ -18893,7 +18937,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19142",
+          "$$hashKey": "object:18106",
           "checked": true,
           "visualize": "true"
         },
@@ -18904,7 +18948,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19143",
+          "$$hashKey": "object:18107",
           "checked": true,
           "visualize": "true"
         },
@@ -18915,7 +18959,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19144",
+          "$$hashKey": "object:18108",
           "checked": true,
           "visualize": "true"
         },
@@ -18926,7 +18970,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19145",
+          "$$hashKey": "object:18109",
           "checked": true,
           "visualize": "true"
         },
@@ -18937,7 +18981,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19146",
+          "$$hashKey": "object:18110",
           "checked": true,
           "visualize": "true"
         },
@@ -18948,7 +18992,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19147",
+          "$$hashKey": "object:18111",
           "checked": true,
           "visualize": "true"
         },
@@ -18959,7 +19003,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19148",
+          "$$hashKey": "object:18112",
           "checked": true,
           "visualize": "true"
         },
@@ -18970,7 +19014,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19149",
+          "$$hashKey": "object:18113",
           "checked": true,
           "visualize": "true"
         },
@@ -18981,7 +19025,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19150",
+          "$$hashKey": "object:18114",
           "checked": true,
           "visualize": "true"
         },
@@ -18992,7 +19036,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19151",
+          "$$hashKey": "object:18115",
           "checked": true,
           "visualize": "true"
         },
@@ -19003,7 +19047,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19152",
+          "$$hashKey": "object:18116",
           "checked": true,
           "visualize": "true"
         },
@@ -19014,7 +19058,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19153",
+          "$$hashKey": "object:18117",
           "checked": true,
           "visualize": "true"
         },
@@ -19025,7 +19069,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19154",
+          "$$hashKey": "object:18118",
           "checked": true,
           "visualize": "true"
         },
@@ -19036,7 +19080,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19155",
+          "$$hashKey": "object:18119",
           "checked": true,
           "visualize": "true"
         },
@@ -19047,7 +19091,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19156",
+          "$$hashKey": "object:18120",
           "checked": true,
           "visualize": "true"
         },
@@ -19058,7 +19102,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19157",
+          "$$hashKey": "object:18121",
           "checked": true,
           "visualize": "true"
         },
@@ -19069,7 +19113,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19158",
+          "$$hashKey": "object:18122",
           "checked": true,
           "visualize": "true"
         },
@@ -19080,7 +19124,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19159",
+          "$$hashKey": "object:18123",
           "checked": true,
           "visualize": "true"
         },
@@ -19091,7 +19135,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19160",
+          "$$hashKey": "object:18124",
           "checked": true,
           "visualize": "true"
         },
@@ -19102,7 +19146,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19161",
+          "$$hashKey": "object:18125",
           "checked": true,
           "visualize": "true"
         },
@@ -19113,7 +19157,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19162",
+          "$$hashKey": "object:18126",
           "checked": true,
           "visualize": "true"
         },
@@ -19124,7 +19168,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19163",
+          "$$hashKey": "object:18127",
           "checked": true,
           "visualize": "true"
         },
@@ -19135,7 +19179,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19164",
+          "$$hashKey": "object:18128",
           "checked": true,
           "visualize": "true"
         },
@@ -19146,7 +19190,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19165",
+          "$$hashKey": "object:18129",
           "checked": true,
           "visualize": "true"
         },
@@ -19157,7 +19201,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19166",
+          "$$hashKey": "object:18130",
           "checked": true,
           "visualize": "true"
         },
@@ -19168,7 +19212,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19167",
+          "$$hashKey": "object:18131",
           "checked": true,
           "visualize": "true"
         },
@@ -19179,7 +19223,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19168",
+          "$$hashKey": "object:18132",
           "checked": true,
           "visualize": "true"
         },
@@ -19190,7 +19234,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19169",
+          "$$hashKey": "object:18133",
           "checked": true,
           "visualize": "true"
         },
@@ -19201,7 +19245,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19170",
+          "$$hashKey": "object:18134",
           "checked": true,
           "visualize": "true"
         },
@@ -19212,7 +19256,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19171",
+          "$$hashKey": "object:18135",
           "checked": true,
           "visualize": "true"
         },
@@ -19223,7 +19267,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19172",
+          "$$hashKey": "object:18136",
           "checked": true,
           "visualize": "true"
         },
@@ -19234,7 +19278,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19173",
+          "$$hashKey": "object:18137",
           "checked": true,
           "visualize": "true"
         },
@@ -19245,7 +19289,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19174",
+          "$$hashKey": "object:18138",
           "checked": true,
           "visualize": "true"
         },
@@ -19256,7 +19300,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19175",
+          "$$hashKey": "object:18139",
           "checked": true,
           "visualize": "true"
         },
@@ -19267,7 +19311,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19176",
+          "$$hashKey": "object:18140",
           "checked": true,
           "visualize": "true"
         },
@@ -19278,7 +19322,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19177",
+          "$$hashKey": "object:18141",
           "checked": true,
           "visualize": "true"
         },
@@ -19289,7 +19333,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19178",
+          "$$hashKey": "object:18142",
           "checked": true,
           "visualize": "true"
         },
@@ -19300,7 +19344,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19179",
+          "$$hashKey": "object:18143",
           "checked": true,
           "visualize": "true"
         },
@@ -19311,7 +19355,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19180",
+          "$$hashKey": "object:18144",
           "checked": true,
           "visualize": "true"
         },
@@ -19322,7 +19366,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19181",
+          "$$hashKey": "object:18145",
           "checked": true,
           "visualize": "true"
         },
@@ -19333,7 +19377,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:19182",
+          "$$hashKey": "object:18146",
           "checked": true,
           "visualize": "true"
         },
@@ -19344,7 +19388,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:19183",
+          "$$hashKey": "object:18147",
           "checked": true,
           "visualize": "true"
         }
@@ -19356,9 +19400,9 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/TimeseriesCSVExport",
       "uid": "2a3442c1-944d-4e91-9e11-11e0cf368c64",
       "uuid": "{2a3442c1-944d-4e91-9e11-11e0cf368c64}",
-      "version_id": "7d687785-9dfb-47b6-84c1-3775bd638174",
-      "version_uuid": "{7d687785-9dfb-47b6-84c1-3775bd638174}",
-      "version_modified": "20191029T154255Z",
+      "version_id": "64696f29-6d80-4418-b20d-61f5bdff5495",
+      "version_uuid": "{64696f29-6d80-4418-b20d-61f5bdff5495}",
+      "version_modified": "20191210T220251Z",
       "xml_checksum": "15BF4E57",
       "display_name": "Timeseries CSV Export",
       "class_name": "TimeseriesCSVExport",
@@ -19413,7 +19457,7 @@
             "stdDev": "Hourly",
             "default_value": "Hourly"
           },
-          "$$hashKey": "object:13803"
+          "$$hashKey": "object:14635"
         },
         {
           "name": "include_enduse_subcategories",
@@ -19437,7 +19481,7 @@
             "stdDev": false,
             "default_value": false
           },
-          "$$hashKey": "object:13804"
+          "$$hashKey": "object:14636"
         },
         {
           "name": "output_variables",
@@ -19460,7 +19504,7 @@
             "stdDev": "",
             "default_value": ""
           },
-          "$$hashKey": "object:13805"
+          "$$hashKey": "object:14637"
         }
       ],
       "edit": "",
@@ -19468,18 +19512,20 @@
       "bcl_update": false,
       "location": "my",
       "add": "",
-      "open": false,
+      "open": true,
       "addedToProject": true,
-      "date": "10/29/2019",
+      "date": "12/10/2019",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.1595560516363448,
+      "instanceId": 0.291334030154615,
       "skip": false,
-      "$$hashKey": "object:13670",
-      "outputMeasure": false
+      "$$hashKey": "object:14592",
+      "outputMeasure": false,
+      "userDefinedOutputs": [],
+      "analysisOutputs": []
     },
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\ServerDirectoryCleanup",
@@ -19523,7 +19569,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.4464299612823741,
+      "instanceId": 0.04219359089403274,
       "skip": false,
       "$$hashKey": "object:663249",
       "outputMeasure": false

--- a/project_testing/measures/SimulationOutputReport/measure.rb
+++ b/project_testing/measures/SimulationOutputReport/measure.rb
@@ -74,6 +74,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "electricity_central_system_cooling_kwh",
       "electricity_interior_lighting_kwh",
       "electricity_exterior_lighting_kwh",
+      "electricity_exterior_holiday_lighting_kwh",
+      "electricity_garage_lighting_kwh",
       "electricity_interior_equipment_kwh",
       "electricity_fans_heating_kwh",
       "electricity_fans_cooling_kwh",
@@ -193,7 +195,6 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
 
     # ELECTRICITY
 
-    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "total_site_electricity_kwh", electricity.total_end_uses[0], "GJ", elec_site_units)
     report_sim_output(runner, "net_site_electricity_kwh", electricity.total_end_uses[0] - electricity.photovoltaics[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_heating_kwh", electricity.heating[0], "GJ", elec_site_units)
@@ -202,8 +203,9 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_cooling_kwh", electricity.central_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_lighting_kwh", electricity.interior_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_exterior_lighting_kwh", electricity.exterior_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_garage_lighting_kwh", electricity.garage_lighting[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_interior_equipment_kwh", electricity.interior_equipment[0], "GJ", elec_site_units)
-    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
 
     # Initialize variables to check against sql file totals
     env_period_ix_query = "SELECT EnvironmentPeriodIndex FROM EnvironmentPeriods WHERE EnvironmentName='#{ann_env_pd}'"
@@ -261,6 +263,8 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "electricity_central_system_pumps_heating_kwh", electricity.central_pumps_heating[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_pumps_cooling_kwh", electricity.pumps_cooling[0], "GJ", elec_site_units)
     report_sim_output(runner, "electricity_central_system_pumps_cooling_kwh", electricity.central_pumps_cooling[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_water_systems_kwh", electricity.water_systems[0], "GJ", elec_site_units)
+    report_sim_output(runner, "electricity_pv_kwh", electricity.photovoltaics[0], "GJ", elec_site_units)
 
     # NATURAL GAS
 

--- a/project_testing/measures/SimulationOutputReport/measure.xml
+++ b/project_testing/measures/SimulationOutputReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>a76e6c10-23a1-4159-b3a3-693195d53895</version_id>
-  <version_modified>20191029T171022Z</version_modified>
+  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
@@ -99,6 +99,20 @@
       <name>electricity_exterior_lighting_kwh</name>
       <display_name>electricity_exterior_lighting_kwh</display_name>
       <short_name>electricity_exterior_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_exterior_holiday_lighting_kwh</name>
+      <display_name>electricity_exterior_holiday_lighting_kwh</display_name>
+      <short_name>electricity_exterior_holiday_lighting_kwh</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>electricity_garage_lighting_kwh</name>
+      <display_name>electricity_garage_lighting_kwh</display_name>
+      <short_name>electricity_garage_lighting_kwh</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -779,7 +793,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9C639C14</checksum>
+      <checksum>0EBF3BC0</checksum>
     </file>
   </files>
 </measure>

--- a/project_testing/measures/TimeseriesCSVExport/measure.rb
+++ b/project_testing/measures/TimeseriesCSVExport/measure.rb
@@ -203,6 +203,8 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "electricity_central_system_cooling_kwh", electricity.central_cooling, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_lighting_kwh", electricity.interior_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_exterior_lighting_kwh", electricity.exterior_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
+    report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_interior_equipment_kwh", electricity.interior_equipment, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_heating_kwh", electricity.fans_heating, "GJ", elec_site_units)
     report_ts_output(runner, timeseries, "electricity_fans_cooling_kwh", electricity.fans_cooling, "GJ", elec_site_units)
@@ -276,8 +278,6 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
       report_ts_output(runner, timeseries, "natural_gas_lighting_therm", natural_gas.lighting, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "natural_gas_fireplace_therm", natural_gas.fireplace, "GJ", gas_site_units)
       report_ts_output(runner, timeseries, "electricity_well_pump_kwh", electricity.well_pump, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_garage_lighting_kwh", electricity.garage_lighting, "GJ", elec_site_units)
-      report_ts_output(runner, timeseries, "electricity_exterior_holiday_lighting_kwh", electricity.exterior_holiday_lighting, "GJ", elec_site_units)
     end
 
     output_vars.each do |output_var|

--- a/project_testing/measures/TimeseriesCSVExport/measure.xml
+++ b/project_testing/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>7d687785-9dfb-47b6-84c1-3775bd638174</version_id>
-  <version_modified>20191029T154255Z</version_modified>
+  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
+  <version_modified>20191210T220251Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,12 +79,6 @@
   </attributes>
   <files>
     <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>B94D34E1</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -93,7 +87,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E2397EB2</checksum>
+      <checksum>6C92E878</checksum>
+    </file>
+    <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>F8C982FF</checksum>
     </file>
   </files>
 </measure>

--- a/project_testing/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_testing/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 34 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 34 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/resources/measures/HPXMLtoOpenStudio/measure.xml
+++ b/resources/measures/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxml_translator</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>83a8344c-9d32-468a-b070-b770d78cbb03</version_id>
-  <version_modified>20191029T154257Z</version_modified>
+  <version_id>5236fdd4-f007-4084-925a-3647a1fbfcbb</version_id>
+  <version_modified>20191210T204902Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLTranslator</class_name>
   <display_name>HPXML Translator</display_name>
@@ -481,7 +481,7 @@
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>F2022969</checksum>
+      <checksum>50A06C8F</checksum>
     </file>
   </files>
 </measure>

--- a/resources/measures/HPXMLtoOpenStudio/resources/util.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/util.rb
@@ -378,13 +378,13 @@ class OutputMeters
     modeledCentralElectricityCooling = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYCOOLING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityExteriorLighting = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYEXTERIORLIGHTING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityExteriorHolidayLighting = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYEXTERIORHOLIDAYLIGHTING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
+    modeledCentralElectricityGarageLighting = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYGARAGELIGHTING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityPumpsHeating = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYPUMPSHEATING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityPumpsCooling = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYPUMPSCOOLING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityInteriorEquipment = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYINTERIOREQUIPMENT') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityPhotovoltaics = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYPHOTOVOLTAICS') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityExtraRefrigerator = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYEXTRAREFRIGERATOR') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
     modeledCentralElectricityFreezer = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYFREEZER') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
-    modeledCentralElectricityGarageLighting = add_unit(sql_file, Vector.elements(Array.new(num_ts, 0.0)), 1, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('CENTRAL:ELECTRICITYGARAGELIGHTING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
 
     # Separate these from non central systems
     centralElectricityHeating = Vector.elements(Array.new(num_ts, 0.0))
@@ -397,7 +397,7 @@ class OutputMeters
     electricityCooling = Vector.elements(Array.new(num_ts, 0.0))
     electricityInteriorLighting = Vector.elements(Array.new(num_ts, 0.0))
     electricityExteriorLighting = Vector.elements(Array.new(num_ts, 0.0))
-    electricityExteriorHolidayLighting = modeledCentralElectricityExteriorHolidayLighting
+    electricityExteriorHolidayLighting = Vector.elements(Array.new(num_ts, 0.0))
     electricityInteriorEquipment = Vector.elements(Array.new(num_ts, 0.0))
     electricityFansHeating = Vector.elements(Array.new(num_ts, 0.0))
     electricityFansCooling = Vector.elements(Array.new(num_ts, 0.0))
@@ -440,6 +440,8 @@ class OutputMeters
       centralElectricityCooling = apportion_central(centralElectricityCooling, modeledCentralElectricityCooling, units_represented, units.length)
       electricityInteriorLighting = add_unit(sql_file, electricityInteriorLighting, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:ELECTRICITYINTERIORLIGHTING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
       electricityExteriorLighting = apportion_central(electricityExteriorLighting, modeledCentralElectricityExteriorLighting, units_represented, units.length)
+      electricityExteriorHolidayLighting = apportion_central(electricityExteriorHolidayLighting, modeledCentralElectricityExteriorHolidayLighting, units_represented, units.length)
+      electricityGarageLighting = apportion_central(electricityGarageLighting, modeledCentralElectricityGarageLighting, units_represented, units.length)
       electricityInteriorEquipment = add_unit(sql_file, electricityInteriorEquipment, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:ELECTRICITYINTERIOREQUIPMENT') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
       electricityInteriorEquipment = apportion_central(electricityInteriorEquipment, modeledCentralElectricityInteriorEquipment, units_represented, units.length)
       electricityFansHeating = add_unit(sql_file, electricityFansHeating, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:ELECTRICITYFANSHEATING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
@@ -470,7 +472,6 @@ class OutputMeters
         electricityHotTubHeater = add_unit(sql_file, electricityHotTubHeater, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:ELECTRICITYHOTTUBHEATER') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
         electricityHotTubPump = add_unit(sql_file, electricityHotTubPump, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:ELECTRICITYHOTTUBPUMP') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
         electricityWellPump = add_unit(sql_file, electricityWellPump, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:ELECTRICITYWELLPUMP') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
-        electricityGarageLighting = apportion_central(electricityGarageLighting, electricityGarageLighting, units_represented, units.length)
       end
     end
 
@@ -480,8 +481,9 @@ class OutputMeters
     @electricity.cooling = electricityCooling
     @electricity.central_cooling = centralElectricityCooling
     @electricity.interior_lighting = electricityInteriorLighting
-    @electricity.exterior_lighting = electricityExteriorLighting + electricityExteriorHolidayLighting
+    @electricity.exterior_lighting = electricityExteriorLighting
     @electricity.exterior_holiday_lighting = electricityExteriorHolidayLighting
+    @electricity.garage_lighting = electricityGarageLighting
     @electricity.interior_equipment = electricityInteriorEquipment
     @electricity.fans_heating = electricityFansHeating
     @electricity.fans_cooling = electricityFansCooling
@@ -510,7 +512,6 @@ class OutputMeters
       @electricity.hot_tub_heater = electricityHotTubHeater
       @electricity.hot_tub_pump = electricityHotTubPump
       @electricity.well_pump = electricityWellPump
-      @electricity.garage_lighting = electricityGarageLighting
     end
 
     @electricity.total_end_uses = @electricity.heating +
@@ -520,6 +521,7 @@ class OutputMeters
                                   @electricity.interior_lighting +
                                   @electricity.exterior_lighting +
                                   @electricity.exterior_holiday_lighting +
+                                  @electricity.garage_lighting +
                                   @electricity.interior_equipment +
                                   @electricity.fans_heating +
                                   @electricity.fans_cooling +
@@ -818,6 +820,8 @@ class OutputMeters
       electricity_cooling(custom_meter_infos, unit, thermal_zones)
       electricity_interior_lighting(custom_meter_infos, unit, thermal_zones)
       electricity_exterior_lighting(custom_meter_infos, unit, thermal_zones)
+      electricity_exterior_holiday_lighting(custom_meter_infos, unit, thermal_zones)
+      electricity_garage_lighting(custom_meter_infos, unit, thermal_zones)
       electricity_interior_equipment(custom_meter_infos, unit, thermal_zones)
       electricity_fans_heating(custom_meter_infos, unit, thermal_zones)
       electricity_fans_cooling(custom_meter_infos, unit, thermal_zones)
@@ -862,7 +866,6 @@ class OutputMeters
         natural_gas_lighting(custom_meter_infos, unit, thermal_zones)
         natural_gas_fireplace(custom_meter_infos, unit, thermal_zones)
         electricity_well_pump(custom_meter_infos, unit, thermal_zones)
-        electricity_garage_lighting(custom_meter_infos, unit, thermal_zones)
       end
     end
 
@@ -1058,12 +1061,18 @@ class OutputMeters
 
   def electricity_exterior_lighting(custom_meter_infos, unit, thermal_zones)
     custom_meter_infos["Central:ElectricityExteriorLighting"] = { "fuel_type" => "Electricity", "key_var_groups" => [] }
+    @model.getExteriorLightss.each do |exterior_lights|
+      if !exterior_lights.endUseSubcategory.include? Constants.ObjectNameLightingExteriorHoliday
+        custom_meter_infos["Central:ElectricityExteriorLighting"]["key_var_groups"] << ["#{exterior_lights.name}", "Exterior Lights Electric Energy"]
+      end
+    end
+  end
+
+  def electricity_exterior_holiday_lighting(custom_meter_infos, unit, thermal_zones)
     custom_meter_infos["Central:ElectricityExteriorHolidayLighting"] = { "fuel_type" => "Electricity", "key_var_groups" => [] }
     @model.getExteriorLightss.each do |exterior_lights|
       if exterior_lights.endUseSubcategory.include? Constants.ObjectNameLightingExteriorHoliday
         custom_meter_infos["Central:ElectricityExteriorHolidayLighting"]["key_var_groups"] << ["#{exterior_lights.name}", "Exterior Lights Electric Energy"]
-      else
-        custom_meter_infos["Central:ElectricityExteriorLighting"]["key_var_groups"] << ["#{exterior_lights.name}", "Exterior Lights Electric Energy"]
       end
     end
   end


### PR DESCRIPTION
## Pull Request Description

Addresses bugs in custom output meters found by @rajeee and @afontani:
* total site electricity double-counting exterior holiday lighting
* garage lighting all zeroes

## Checklist

Not all may apply:

- [x] Unit tests have been added or updated
- [x] All rake tasks have been run, and pass
- [x] PAT project measures/outputs have been updated
- [x] Documentation has been modified appropriately
- [ ] ~Any new options are added to `project_testing`~
- [ ] ~`project_testing` runs without any failures~
- [x] No unexpected regression test changes
- [x] All tests are passing (green) on circleci
- [x] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [x] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).