### PR TITLE
Fixes wood stove upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Features
 - Separate tsv files for bedrooms, cooking range schedule, corridor, holiday lighting, interior/other lighting use, pool schedule, plug loads schedule, and refrigeration schedule ([#338](https://github.com/NREL/OpenStudio-BuildStock/pull/338))
 
 Fixes
-- Account for wood heating energy in simulation output ([#372](https://github.com/NREL/OpenStudio-BuildStock/pull/372))
+- Allow Wood Stove option as an upgrade, and acccount for wood heating energy in simulation output ([#372](https://github.com/NREL/OpenStudio-BuildStock/pull/372))
 - Some re-labeling of tsv files, such as "Geometry Building Type" to "Geometry Building Type RECS" and "Geometry Building Type FPL" to "Geometry Building Type ACS" ([#356](https://github.com/NREL/OpenStudio-BuildStock/pull/356))
 - Removes option "Auto" from parameter "Occupants" in the options lookup file ([#360](https://github.com/NREL/OpenStudio-BuildStock/pull/360))
 - Update the multifamily project's neighbors and orientation tsv files to have geometry building type dependency; remove the now obsolete "Geometry Is Multifamily Low Rise.tsv" file ([#350](https://github.com/NREL/OpenStudio-BuildStock/pull/350))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features
 - Separate tsv files for bedrooms, cooking range schedule, corridor, holiday lighting, interior/other lighting use, pool schedule, plug loads schedule, and refrigeration schedule ([#338](https://github.com/NREL/OpenStudio-BuildStock/pull/338))
 
 Fixes
+- Account for wood heating energy in simulation output ([#372](https://github.com/NREL/OpenStudio-BuildStock/pull/372))
 - Some re-labeling of tsv files, such as "Geometry Building Type" to "Geometry Building Type RECS" and "Geometry Building Type FPL" to "Geometry Building Type ACS" ([#356](https://github.com/NREL/OpenStudio-BuildStock/pull/356))
 - Removes option "Auto" from parameter "Occupants" in the options lookup file ([#360](https://github.com/NREL/OpenStudio-BuildStock/pull/360))
 - Update the multifamily project's neighbors and orientation tsv files to have geometry building type dependency; remove the now obsolete "Geometry Is Multifamily Low Rise.tsv" file ([#350](https://github.com/NREL/OpenStudio-BuildStock/pull/350))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Features
 - Separate tsv files for bedrooms, cooking range schedule, corridor, holiday lighting, interior/other lighting use, pool schedule, plug loads schedule, and refrigeration schedule ([#338](https://github.com/NREL/OpenStudio-BuildStock/pull/338))
 
 Fixes
-- Allow Wood Stove option as an upgrade, and acccount for wood heating energy in simulation output ([#372](https://github.com/NREL/OpenStudio-BuildStock/pull/372))
+- Allow Wood Stove option as an upgrade, and account for wood heating energy in simulation output ([#372](https://github.com/NREL/OpenStudio-BuildStock/pull/372))
 - Some re-labeling of tsv files, such as "Geometry Building Type" to "Geometry Building Type RECS" and "Geometry Building Type FPL" to "Geometry Building Type ACS" ([#356](https://github.com/NREL/OpenStudio-BuildStock/pull/356))
 - Removes option "Auto" from parameter "Occupants" in the options lookup file ([#360](https://github.com/NREL/OpenStudio-BuildStock/pull/360))
 - Update the multifamily project's neighbors and orientation tsv files to have geometry building type dependency; remove the now obsolete "Geometry Is Multifamily Low Rise.tsv" file ([#350](https://github.com/NREL/OpenStudio-BuildStock/pull/350))

--- a/measures/BuildingCharacteristicsReport/measure.xml
+++ b/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>da2102f5-b790-465d-9394-f012fe4ddad3</version_id>
-  <version_modified>20200118T172411Z</version_modified>
+  <version_id>1f44b04d-9e14-4f5d-8c10-7240262b845c</version_id>
+  <version_modified>20200123T175727Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -906,7 +906,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CE447A1E</checksum>
+      <checksum>F5F682BD</checksum>
     </file>
   </files>
 </measure>

--- a/measures/SimulationOutputReport/measure.rb
+++ b/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation outputs of interest."
+    return "Reports simulation ou tputs of interest."
   end
 
   def num_options
@@ -66,6 +66,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "total_site_natural_gas_therm",
       "total_site_fuel_oil_mbtu",
       "total_site_propane_mbtu",
+      "total_site_wood_mbtu",
       "net_site_energy_mbtu", # Incorporates PV
       "net_site_electricity_kwh", # Incorporates PV
       "electricity_heating_kwh",
@@ -97,6 +98,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "propane_central_system_heating_mbtu",
       "propane_interior_equipment_mbtu",
       "propane_water_systems_mbtu",
+      "wood_heating_mbtu",
       "hours_heating_setpoint_not_met",
       "hours_cooling_setpoint_not_met",
       "hvac_cooling_capacity_w",
@@ -191,6 +193,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
     hours_setpoint_not_met = output_meters.hours_setpoint_not_met(sqlFile)
 
     # ELECTRICITY
@@ -290,12 +293,18 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "propane_interior_equipment_mbtu", propane.interior_equipment[0], "GJ", other_fuel_site_units)
     report_sim_output(runner, "propane_water_systems_mbtu", propane.water_systems[0], "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_sim_output(runner, "total_site_wood_mbtu", wood.total_end_uses[0], "GJ", other_fuel_site_units)
+    report_sim_output(runner, "wood_heating_mbtu", wood.heating[0], "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses[0] +
                       natural_gas.total_end_uses[0] +
                       fuel_oil.total_end_uses[0] +
-                      propane.total_end_uses[0]
+                      propane.total_end_uses[0] +
+                      wood.total_end_uses[0]
 
     if units.length == total_units_represented
       err = totalSiteEnergy - sqlFile.totalSiteEnergy.get

--- a/measures/SimulationOutputReport/measure.rb
+++ b/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation ou tputs of interest."
+    return "Reports simulation outputs of interest."
   end
 
   def num_options

--- a/measures/SimulationOutputReport/measure.xml
+++ b/measures/SimulationOutputReport/measure.xml
@@ -2,12 +2,12 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>2992ab1b-5569-465c-a32b-c622a453a3cb</version_id>
+  <version_modified>20200123T175728Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
-  <description>Reports simulation outputs of interest.</description>
+  <description>Reports simulation ou tputs of interest.</description>
   <modeler_description>Change me</modeler_description>
   <arguments/>
   <outputs>
@@ -43,6 +43,13 @@
       <name>total_site_propane_mbtu</name>
       <display_name>total_site_propane_mbtu</display_name>
       <short_name>total_site_propane_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>total_site_wood_mbtu</name>
+      <display_name>total_site_wood_mbtu</display_name>
+      <short_name>total_site_wood_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -260,6 +267,13 @@
       <name>propane_water_systems_mbtu</name>
       <display_name>propane_water_systems_mbtu</display_name>
       <short_name>propane_water_systems_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>wood_heating_mbtu</name>
+      <display_name>wood_heating_mbtu</display_name>
+      <short_name>wood_heating_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -793,7 +807,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0EBF3BC0</checksum>
+      <checksum>11288408</checksum>
     </file>
   </files>
 </measure>

--- a/measures/TimeseriesCSVExport/measure.rb
+++ b/measures/TimeseriesCSVExport/measure.rb
@@ -192,6 +192,7 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
 
     # ELECTRICITY
 
@@ -239,12 +240,18 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "propane_interior_equipment_mbtu", propane.interior_equipment, "GJ", other_fuel_site_units)
     report_ts_output(runner, timeseries, "propane_water_systems_mbtu", propane.water_systems, "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_ts_output(runner, timeseries, "total_site_wood_mbtu", wood.total_end_uses, "GJ", other_fuel_site_units)
+    report_ts_output(runner, timeseries, "wood_heating_mbtu", wood.heating, "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses +
                       natural_gas.total_end_uses +
                       fuel_oil.total_end_uses +
-                      propane.total_end_uses
+                      propane.total_end_uses +
+                      wood.total_end_uses
 
     report_ts_output(runner, timeseries, "total_site_energy_mbtu", totalSiteEnergy, "GJ", total_site_units)
     report_ts_output(runner, timeseries, "net_site_energy_mbtu", totalSiteEnergy - electricity.photovoltaics, "GJ", total_site_units)

--- a/measures/TimeseriesCSVExport/measure.xml
+++ b/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03</version_id>
+  <version_modified>20200123T180929Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,6 +79,12 @@
   </attributes>
   <files>
     <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3A9D58E2</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -87,13 +93,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6C92E878</checksum>
-    </file>
-    <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F8C982FF</checksum>
+      <checksum>731388DC</checksum>
     </file>
   </files>
 </measure>

--- a/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -13,7 +13,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Timestep"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Zone Mean Air Temperature, Site Outdoor Air Drybulb Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 34 + 28 + 5 }
+    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 36 + 28 + 5 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2012.epw", num_output_requests)
   end
 

--- a/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -73,7 +73,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Electric Equipment Electric Power, Zone Air Heat Balance Internal Convective Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 9 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 9 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -106,7 +106,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Daily"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Cooling Coil Runtime Fraction, Unitary System Ancillary Electric Power, System Node Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 1 }
     _test_measure("MF_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_multifamily_beta/measures/BuildingCharacteristicsReport/measure.xml
+++ b/project_multifamily_beta/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>da2102f5-b790-465d-9394-f012fe4ddad3</version_id>
-  <version_modified>20200118T172411Z</version_modified>
+  <version_id>1f44b04d-9e14-4f5d-8c10-7240262b845c</version_id>
+  <version_modified>20200123T175727Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -906,7 +906,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CE447A1E</checksum>
+      <checksum>F5F682BD</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/measures/SimulationOutputReport/measure.rb
+++ b/project_multifamily_beta/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation outputs of interest."
+    return "Reports simulation ou tputs of interest."
   end
 
   def num_options
@@ -66,6 +66,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "total_site_natural_gas_therm",
       "total_site_fuel_oil_mbtu",
       "total_site_propane_mbtu",
+      "total_site_wood_mbtu",
       "net_site_energy_mbtu", # Incorporates PV
       "net_site_electricity_kwh", # Incorporates PV
       "electricity_heating_kwh",
@@ -97,6 +98,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "propane_central_system_heating_mbtu",
       "propane_interior_equipment_mbtu",
       "propane_water_systems_mbtu",
+      "wood_heating_mbtu",
       "hours_heating_setpoint_not_met",
       "hours_cooling_setpoint_not_met",
       "hvac_cooling_capacity_w",
@@ -191,6 +193,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
     hours_setpoint_not_met = output_meters.hours_setpoint_not_met(sqlFile)
 
     # ELECTRICITY
@@ -290,12 +293,18 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "propane_interior_equipment_mbtu", propane.interior_equipment[0], "GJ", other_fuel_site_units)
     report_sim_output(runner, "propane_water_systems_mbtu", propane.water_systems[0], "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_sim_output(runner, "total_site_wood_mbtu", wood.total_end_uses[0], "GJ", other_fuel_site_units)
+    report_sim_output(runner, "wood_heating_mbtu", wood.heating[0], "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses[0] +
                       natural_gas.total_end_uses[0] +
                       fuel_oil.total_end_uses[0] +
-                      propane.total_end_uses[0]
+                      propane.total_end_uses[0] +
+                      wood.total_end_uses[0]
 
     if units.length == total_units_represented
       err = totalSiteEnergy - sqlFile.totalSiteEnergy.get

--- a/project_multifamily_beta/measures/SimulationOutputReport/measure.rb
+++ b/project_multifamily_beta/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation ou tputs of interest."
+    return "Reports simulation outputs of interest."
   end
 
   def num_options

--- a/project_multifamily_beta/measures/SimulationOutputReport/measure.xml
+++ b/project_multifamily_beta/measures/SimulationOutputReport/measure.xml
@@ -2,12 +2,12 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>2992ab1b-5569-465c-a32b-c622a453a3cb</version_id>
+  <version_modified>20200123T175728Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
-  <description>Reports simulation outputs of interest.</description>
+  <description>Reports simulation ou tputs of interest.</description>
   <modeler_description>Change me</modeler_description>
   <arguments/>
   <outputs>
@@ -43,6 +43,13 @@
       <name>total_site_propane_mbtu</name>
       <display_name>total_site_propane_mbtu</display_name>
       <short_name>total_site_propane_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>total_site_wood_mbtu</name>
+      <display_name>total_site_wood_mbtu</display_name>
+      <short_name>total_site_wood_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -260,6 +267,13 @@
       <name>propane_water_systems_mbtu</name>
       <display_name>propane_water_systems_mbtu</display_name>
       <short_name>propane_water_systems_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>wood_heating_mbtu</name>
+      <display_name>wood_heating_mbtu</display_name>
+      <short_name>wood_heating_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -793,7 +807,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0EBF3BC0</checksum>
+      <checksum>11288408</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/measure.rb
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/measure.rb
@@ -192,6 +192,7 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
 
     # ELECTRICITY
 
@@ -239,12 +240,18 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "propane_interior_equipment_mbtu", propane.interior_equipment, "GJ", other_fuel_site_units)
     report_ts_output(runner, timeseries, "propane_water_systems_mbtu", propane.water_systems, "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_ts_output(runner, timeseries, "total_site_wood_mbtu", wood.total_end_uses, "GJ", other_fuel_site_units)
+    report_ts_output(runner, timeseries, "wood_heating_mbtu", wood.heating, "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses +
                       natural_gas.total_end_uses +
                       fuel_oil.total_end_uses +
-                      propane.total_end_uses
+                      propane.total_end_uses +
+                      wood.total_end_uses
 
     report_ts_output(runner, timeseries, "total_site_energy_mbtu", totalSiteEnergy, "GJ", total_site_units)
     report_ts_output(runner, timeseries, "net_site_energy_mbtu", totalSiteEnergy - electricity.photovoltaics, "GJ", total_site_units)

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/measure.xml
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03</version_id>
+  <version_modified>20200123T180929Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,6 +79,12 @@
   </attributes>
   <files>
     <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3A9D58E2</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -87,13 +93,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6C92E878</checksum>
-    </file>
-    <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F8C982FF</checksum>
+      <checksum>731388DC</checksum>
     </file>
   </files>
 </measure>

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -13,7 +13,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Timestep"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Zone Mean Air Temperature, Site Outdoor Air Drybulb Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 34 + 28 + 5 }
+    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 36 + 28 + 5 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2012.epw", num_output_requests)
   end
 

--- a/project_multifamily_beta/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_multifamily_beta/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -73,7 +73,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Electric Equipment Electric Power, Zone Air Heat Balance Internal Convective Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 9 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 9 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -106,7 +106,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Daily"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Cooling Coil Runtime Fraction, Unitary System Ancillary Electric Power, System Node Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 1 }
     _test_measure("MF_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_multifamily_beta/pat.json
+++ b/project_multifamily_beta/pat.json
@@ -312,7 +312,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.6083462432289737,
+      "instanceId": 0.25702327120341484,
       "skip": false,
       "$$hashKey": "object:11247",
       "outputMeasure": false
@@ -320,7 +320,7 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildExistingModel",
       "name": "build_existing_model",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildExistingModel",
       "uid": "dedf59bb-3b88-4f16-8755-2c1ff5519cbf",
       "uuid": "{dedf59bb-3b88-4f16-8755-2c1ff5519cbf}",
       "version_id": "ddb1178a-cb38-492a-84d7-534fd5d25142",
@@ -494,7 +494,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.12306799049622841,
+      "instanceId": 0.46210373280720707,
       "skip": false,
       "$$hashKey": "object:32347",
       "showWarningText": false,
@@ -7316,7 +7316,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.9014681404986133,
+      "instanceId": 0.7230572095726868,
       "skip": false,
       "$$hashKey": "object:32853",
       "showWarningText": false,
@@ -14138,21 +14138,21 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.6160412823157482,
+      "instanceId": 0.037686782093427684,
       "skip": false,
       "$$hashKey": "object:39018",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\BuildingCharacteristicsReport",
+      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "name": "building_characteristics_report",
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
-      "version_id": "da2102f5-b790-465d-9394-f012fe4ddad3",
-      "version_uuid": "{da2102f5-b790-465d-9394-f012fe4ddad3}",
-      "version_modified": "20200118T172411Z",
+      "version_id": "1f44b04d-9e14-4f5d-8c10-7240262b845c",
+      "version_uuid": "{1f44b04d-9e14-4f5d-8c10-7240262b845c}",
+      "version_modified": "20200123T175727Z",
       "xml_checksum": "2EA103AF",
       "display_name": "Building Characteristics Report",
       "class_name": "BuildingCharacteristicsReport",
@@ -14167,9 +14167,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49447",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_heating_region",
@@ -14178,9 +14176,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49448",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_cooling_region",
@@ -14189,9 +14185,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49449",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location",
@@ -14200,9 +14194,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49450",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_weather_filename",
@@ -14211,9 +14203,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49451",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_weather_year",
@@ -14222,9 +14212,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49452",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "vintage",
@@ -14233,9 +14221,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49453",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "vintage_acs",
@@ -14244,9 +14230,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49454",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_fuel",
@@ -14255,9 +14239,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49455",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "usage_level",
@@ -14266,9 +14248,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49456",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_attic_type",
@@ -14277,9 +14257,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49457",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_type_recs",
@@ -14288,9 +14266,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49458",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_type_acs",
@@ -14299,9 +14275,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49459",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_number_units",
@@ -14310,9 +14284,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49460",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_mf",
@@ -14321,9 +14293,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49461",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_sfa",
@@ -14332,9 +14302,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49462",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_hl",
@@ -14343,9 +14311,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49463",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_foundation_type",
@@ -14354,9 +14320,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49464",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_heated_basement",
@@ -14365,9 +14329,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49465",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_wall_type",
@@ -14376,9 +14338,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49466",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_stories",
@@ -14387,9 +14347,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49467",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_garage",
@@ -14398,9 +14356,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49468",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_house_size",
@@ -14409,9 +14365,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49469",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "bedrooms",
@@ -14420,9 +14374,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49470",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "corridor",
@@ -14431,9 +14383,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49471",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_number_units_acs_bins",
@@ -14442,9 +14392,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49472",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_unit_stories_sf",
@@ -14453,9 +14401,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49473",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_unit_stories_mf",
@@ -14464,9 +14410,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49474",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "occupants",
@@ -14475,9 +14419,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49475",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "orientation",
@@ -14486,9 +14428,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49476",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "eaves",
@@ -14497,9 +14437,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49477",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "door_area",
@@ -14508,9 +14446,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49478",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "window_areas",
@@ -14519,9 +14455,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49479",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "overhangs",
@@ -14530,9 +14464,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49480",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "neighbors",
@@ -14541,9 +14473,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49481",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_unfinished_attic",
@@ -14552,9 +14482,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49482",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_finished_roof",
@@ -14563,9 +14491,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49483",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "radiant_barrier_unfinished_attic",
@@ -14574,9 +14500,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49484",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "roof_material",
@@ -14585,9 +14509,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49485",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_slab",
@@ -14596,9 +14518,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49486",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_crawlspace",
@@ -14607,9 +14527,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49487",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_unfinished_basement",
@@ -14618,9 +14536,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49488",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_finished_basement",
@@ -14629,9 +14545,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49489",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_pier_beam",
@@ -14640,9 +14554,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49490",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_interzonal_floor",
@@ -14651,9 +14563,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49491",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_wall",
@@ -14662,9 +14572,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49492",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "interior_shading",
@@ -14673,9 +14581,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49493",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "windows",
@@ -14684,9 +14590,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49494",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "doors",
@@ -14695,9 +14599,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49495",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "water_heater",
@@ -14706,9 +14608,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49496",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hot_water_fixtures",
@@ -14717,9 +14617,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49497",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hot_water_distribution",
@@ -14728,9 +14626,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49498",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "solar_hot_water",
@@ -14739,9 +14635,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49499",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_is_shared",
@@ -14750,9 +14644,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49500",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_electricity",
@@ -14761,9 +14653,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49501",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_natural_gas",
@@ -14772,9 +14662,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49502",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_propane",
@@ -14783,9 +14671,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49503",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_fuel_oil",
@@ -14794,9 +14680,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49504",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_other_fuel",
@@ -14805,9 +14689,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49505",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_none",
@@ -14816,9 +14698,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49506",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_is_heat_pump",
@@ -14827,9 +14707,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49507",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heat_pump",
@@ -14838,9 +14716,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49508",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_electricity",
@@ -14849,9 +14725,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49509",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_natural_gas",
@@ -14860,9 +14734,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49510",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_propane",
@@ -14871,9 +14743,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49511",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_fuel_oil",
@@ -14882,9 +14752,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49512",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_wood",
@@ -14893,9 +14761,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49513",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_other_fuel",
@@ -14904,9 +14770,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49514",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_none",
@@ -14915,9 +14779,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49515",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_cooling",
@@ -14926,9 +14788,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49516",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_cooling_type",
@@ -14937,9 +14797,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49517",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint",
@@ -14948,9 +14806,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49518",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint",
@@ -14959,9 +14815,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49519",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_has_offset",
@@ -14970,9 +14824,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49520",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_has_offset",
@@ -14981,9 +14833,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49521",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_offset_magnitude",
@@ -14992,9 +14842,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49522",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_offset_magnitude",
@@ -15003,9 +14851,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49523",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_offset_period",
@@ -15014,9 +14860,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49524",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_offset_period",
@@ -15025,9 +14869,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49525",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "setpoint_demand_response",
@@ -15036,9 +14878,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49526",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "ceiling_fan",
@@ -15047,9 +14887,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49527",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "dehumidifier",
@@ -15058,9 +14896,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49528",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "refrigerator",
@@ -15069,9 +14905,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49529",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "refrigeration_schedule",
@@ -15080,9 +14914,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49530",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooking_range",
@@ -15091,9 +14923,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49531",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooking_range_schedule",
@@ -15102,9 +14932,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49532",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "dishwasher",
@@ -15113,9 +14941,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49533",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "clothes_washer",
@@ -15124,9 +14950,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49534",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "clothes_dryer",
@@ -15135,9 +14959,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49535",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting",
@@ -15146,9 +14968,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49536",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting_interior_use",
@@ -15157,9 +14977,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49537",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting_other_use",
@@ -15168,9 +14986,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49538",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "holiday_lighting",
@@ -15179,9 +14995,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49539",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "plug_loads",
@@ -15190,9 +15004,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49540",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "plug_loads_schedule",
@@ -15201,9 +15013,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49541",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "electric_vehicle",
@@ -15212,9 +15022,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49542",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_extra_refrigerator",
@@ -15223,9 +15031,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49543",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_freezer",
@@ -15234,9 +15040,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49544",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_fireplace",
@@ -15245,9 +15049,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49545",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_grill",
@@ -15256,9 +15058,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49546",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_lighting",
@@ -15267,9 +15067,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49547",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_hot_tub_spa",
@@ -15278,9 +15076,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49548",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool",
@@ -15289,9 +15085,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49549",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_heater",
@@ -15300,9 +15094,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49550",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_pump",
@@ -15311,9 +15103,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49551",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_schedule",
@@ -15322,9 +15112,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49552",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_well_pump",
@@ -15333,9 +15121,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49553",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "ducts",
@@ -15344,9 +15130,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49554",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "infiltration",
@@ -15355,9 +15139,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49555",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "natural_ventilation",
@@ -15366,9 +15148,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49556",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "mechanical_ventilation",
@@ -15377,9 +15157,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49557",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "bathroom_spot_vent_hour",
@@ -15388,9 +15166,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49558",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "range_spot_vent_hour",
@@ -15399,9 +15175,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49559",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "pv",
@@ -15410,9 +15184,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49560",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "days_shifted",
@@ -15421,9 +15193,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49561",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_perimeter_footprint_ratio",
@@ -15432,9 +15202,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49562",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_city",
@@ -15443,9 +15211,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49563",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_state",
@@ -15454,9 +15220,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49564",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_latitude",
@@ -15465,9 +15229,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49565",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_longitude",
@@ -15476,9 +15238,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49566",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "climate_zone_ba",
@@ -15487,9 +15247,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49567",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "climate_zone_iecc",
@@ -15498,9 +15256,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49568",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "units_represented",
@@ -15509,9 +15265,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49569",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "units_modeled",
@@ -15520,9 +15274,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:49570",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         }
       ],
       "attributes": [
@@ -15545,13 +15297,13 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "1/18/2020",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.5212936624614619,
+      "instanceId": 0.30662321881179144,
       "skip": false,
       "$$hashKey": "object:49153",
       "outputMeasure": true,
@@ -16929,13 +16681,13 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/SimulationOutputReport",
       "uid": "fc337100-8634-404e-8966-01243d292a79",
       "uuid": "{fc337100-8634-404e-8966-01243d292a79}",
-      "version_id": "452c3c75-928b-4c49-93f5-dc319088b009",
-      "version_uuid": "{452c3c75-928b-4c49-93f5-dc319088b009}",
-      "version_modified": "20191210T220251Z",
+      "version_id": "2992ab1b-5569-465c-a32b-c622a453a3cb",
+      "version_uuid": "{2992ab1b-5569-465c-a32b-c622a453a3cb}",
+      "version_modified": "20200123T175728Z",
       "xml_checksum": "2C8A3EEF",
       "display_name": "Simulation Output Report",
       "class_name": "SimulationOutputReport",
-      "description": "Reports simulation outputs of interest.",
+      "description": "Reports simulation ou tputs of interest.",
       "modeler_description": "Change me",
       "tags": "Reporting.QAQC",
       "outputs": [
@@ -16946,7 +16698,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53275",
+          "$$hashKey": "object:54180",
           "checked": true,
           "visualize": "true"
         },
@@ -16957,7 +16709,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53276",
+          "$$hashKey": "object:54181",
           "checked": true,
           "visualize": "true"
         },
@@ -16968,7 +16720,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53277",
+          "$$hashKey": "object:54182",
           "checked": true,
           "visualize": "true"
         },
@@ -16979,7 +16731,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53278",
+          "$$hashKey": "object:54183",
           "checked": true,
           "visualize": "true"
         },
@@ -16990,7 +16742,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53279",
+          "$$hashKey": "object:54184",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "total_site_wood_mbtu",
+          "display_name": "total_site_wood_mbtu",
+          "short_name": "total_site_wood_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:54185",
           "checked": true,
           "visualize": "true"
         },
@@ -17001,7 +16764,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53280",
+          "$$hashKey": "object:54186",
           "checked": true,
           "visualize": "true"
         },
@@ -17012,7 +16775,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53281",
+          "$$hashKey": "object:54187",
           "checked": true,
           "visualize": "true"
         },
@@ -17023,7 +16786,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53282",
+          "$$hashKey": "object:54188",
           "checked": true,
           "visualize": "true"
         },
@@ -17034,7 +16797,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53283",
+          "$$hashKey": "object:54189",
           "checked": true,
           "visualize": "true"
         },
@@ -17045,7 +16808,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53284",
+          "$$hashKey": "object:54190",
           "checked": true,
           "visualize": "true"
         },
@@ -17056,7 +16819,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53285",
+          "$$hashKey": "object:54191",
           "checked": true,
           "visualize": "true"
         },
@@ -17067,7 +16830,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53286",
+          "$$hashKey": "object:54192",
           "checked": true,
           "visualize": "true"
         },
@@ -17078,7 +16841,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53287",
+          "$$hashKey": "object:54193",
           "checked": true,
           "visualize": "true"
         },
@@ -17089,7 +16852,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53288",
+          "$$hashKey": "object:54194",
           "checked": true,
           "visualize": "true"
         },
@@ -17100,7 +16863,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53289",
+          "$$hashKey": "object:54195",
           "checked": true,
           "visualize": "true"
         },
@@ -17111,7 +16874,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53290",
+          "$$hashKey": "object:54196",
           "checked": true,
           "visualize": "true"
         },
@@ -17122,7 +16885,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53291",
+          "$$hashKey": "object:54197",
           "checked": true,
           "visualize": "true"
         },
@@ -17133,7 +16896,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53292",
+          "$$hashKey": "object:54198",
           "checked": true,
           "visualize": "true"
         },
@@ -17144,7 +16907,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53293",
+          "$$hashKey": "object:54199",
           "checked": true,
           "visualize": "true"
         },
@@ -17155,7 +16918,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53294",
+          "$$hashKey": "object:54200",
           "checked": true,
           "visualize": "true"
         },
@@ -17166,7 +16929,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53295",
+          "$$hashKey": "object:54201",
           "checked": true,
           "visualize": "true"
         },
@@ -17177,7 +16940,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53296",
+          "$$hashKey": "object:54202",
           "checked": true,
           "visualize": "true"
         },
@@ -17188,7 +16951,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53297",
+          "$$hashKey": "object:54203",
           "checked": true,
           "visualize": "true"
         },
@@ -17199,7 +16962,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53298",
+          "$$hashKey": "object:54204",
           "checked": true,
           "visualize": "true"
         },
@@ -17210,7 +16973,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53299",
+          "$$hashKey": "object:54205",
           "checked": true,
           "visualize": "true"
         },
@@ -17221,7 +16984,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53300",
+          "$$hashKey": "object:54206",
           "checked": true,
           "visualize": "true"
         },
@@ -17232,7 +16995,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53301",
+          "$$hashKey": "object:54207",
           "checked": true,
           "visualize": "true"
         },
@@ -17243,7 +17006,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53302",
+          "$$hashKey": "object:54208",
           "checked": true,
           "visualize": "true"
         },
@@ -17254,7 +17017,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53303",
+          "$$hashKey": "object:54209",
           "checked": true,
           "visualize": "true"
         },
@@ -17265,7 +17028,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53304",
+          "$$hashKey": "object:54210",
           "checked": true,
           "visualize": "true"
         },
@@ -17276,7 +17039,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53305",
+          "$$hashKey": "object:54211",
           "checked": true,
           "visualize": "true"
         },
@@ -17287,7 +17050,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53306",
+          "$$hashKey": "object:54212",
           "checked": true,
           "visualize": "true"
         },
@@ -17298,7 +17061,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53307",
+          "$$hashKey": "object:54213",
           "checked": true,
           "visualize": "true"
         },
@@ -17309,7 +17072,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53308",
+          "$$hashKey": "object:54214",
           "checked": true,
           "visualize": "true"
         },
@@ -17320,7 +17083,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53309",
+          "$$hashKey": "object:54215",
           "checked": true,
           "visualize": "true"
         },
@@ -17331,7 +17094,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53310",
+          "$$hashKey": "object:54216",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "wood_heating_mbtu",
+          "display_name": "wood_heating_mbtu",
+          "short_name": "wood_heating_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:54217",
           "checked": true,
           "visualize": "true"
         },
@@ -17342,7 +17116,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53311",
+          "$$hashKey": "object:54218",
           "checked": true,
           "visualize": "true"
         },
@@ -17353,7 +17127,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53312",
+          "$$hashKey": "object:54219",
           "checked": true,
           "visualize": "true"
         },
@@ -17364,7 +17138,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53313",
+          "$$hashKey": "object:54220",
           "checked": true,
           "visualize": "true"
         },
@@ -17375,7 +17149,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53314",
+          "$$hashKey": "object:54221",
           "checked": true,
           "visualize": "true"
         },
@@ -17386,7 +17160,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53315",
+          "$$hashKey": "object:54222",
           "checked": true,
           "visualize": "true"
         },
@@ -17397,7 +17171,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53316",
+          "$$hashKey": "object:54223",
           "checked": true,
           "visualize": "true"
         },
@@ -17408,7 +17182,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53317",
+          "$$hashKey": "object:54224",
           "checked": true,
           "visualize": "true"
         },
@@ -17419,7 +17193,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53318",
+          "$$hashKey": "object:54225",
           "checked": true,
           "visualize": "true"
         },
@@ -17430,7 +17204,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53319",
+          "$$hashKey": "object:54226",
           "checked": true,
           "visualize": "true"
         },
@@ -17441,7 +17215,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53320",
+          "$$hashKey": "object:54227",
           "checked": true,
           "visualize": "true"
         },
@@ -17452,7 +17226,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53321",
+          "$$hashKey": "object:54228",
           "checked": true,
           "visualize": "true"
         },
@@ -17463,7 +17237,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53322",
+          "$$hashKey": "object:54229",
           "checked": true,
           "visualize": "true"
         },
@@ -17474,7 +17248,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53323",
+          "$$hashKey": "object:54230",
           "checked": true,
           "visualize": "true"
         },
@@ -17485,7 +17259,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53324",
+          "$$hashKey": "object:54231",
           "checked": true,
           "visualize": "true"
         },
@@ -17496,7 +17270,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53325",
+          "$$hashKey": "object:54232",
           "checked": true,
           "visualize": "true"
         },
@@ -17507,7 +17281,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53326",
+          "$$hashKey": "object:54233",
           "checked": true,
           "visualize": "true"
         },
@@ -17518,7 +17292,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53327",
+          "$$hashKey": "object:54234",
           "checked": true,
           "visualize": "true"
         },
@@ -17529,7 +17303,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53328",
+          "$$hashKey": "object:54235",
           "checked": true,
           "visualize": "true"
         },
@@ -17540,7 +17314,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53329",
+          "$$hashKey": "object:54236",
           "checked": true,
           "visualize": "true"
         },
@@ -17551,7 +17325,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53330",
+          "$$hashKey": "object:54237",
           "checked": true,
           "visualize": "true"
         },
@@ -17562,7 +17336,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53331",
+          "$$hashKey": "object:54238",
           "checked": true,
           "visualize": "true"
         },
@@ -17573,7 +17347,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53332",
+          "$$hashKey": "object:54239",
           "checked": true,
           "visualize": "true"
         },
@@ -17584,7 +17358,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53333",
+          "$$hashKey": "object:54240",
           "checked": true,
           "visualize": "true"
         },
@@ -17595,7 +17369,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53334",
+          "$$hashKey": "object:54241",
           "checked": true,
           "visualize": "true"
         },
@@ -17606,7 +17380,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53335",
+          "$$hashKey": "object:54242",
           "checked": true,
           "visualize": "true"
         },
@@ -17617,7 +17391,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53336",
+          "$$hashKey": "object:54243",
           "checked": true,
           "visualize": "true"
         },
@@ -17628,7 +17402,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53337",
+          "$$hashKey": "object:54244",
           "checked": true,
           "visualize": "true"
         },
@@ -17639,7 +17413,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53338",
+          "$$hashKey": "object:54245",
           "checked": true,
           "visualize": "true"
         },
@@ -17650,7 +17424,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53339",
+          "$$hashKey": "object:54246",
           "checked": true,
           "visualize": "true"
         },
@@ -17661,7 +17435,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53340",
+          "$$hashKey": "object:54247",
           "checked": true,
           "visualize": "true"
         },
@@ -17672,7 +17446,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53341",
+          "$$hashKey": "object:54248",
           "checked": true,
           "visualize": "true"
         },
@@ -17683,7 +17457,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53342",
+          "$$hashKey": "object:54249",
           "checked": true,
           "visualize": "true"
         },
@@ -17694,7 +17468,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53343",
+          "$$hashKey": "object:54250",
           "checked": true,
           "visualize": "true"
         },
@@ -17705,7 +17479,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53344",
+          "$$hashKey": "object:54251",
           "checked": true,
           "visualize": "true"
         },
@@ -17716,7 +17490,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53345",
+          "$$hashKey": "object:54252",
           "checked": true,
           "visualize": "true"
         },
@@ -17727,7 +17501,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53346",
+          "$$hashKey": "object:54253",
           "checked": true,
           "visualize": "true"
         },
@@ -17738,7 +17512,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53347",
+          "$$hashKey": "object:54254",
           "checked": true,
           "visualize": "true"
         },
@@ -17749,7 +17523,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53348",
+          "$$hashKey": "object:54255",
           "checked": true,
           "visualize": "true"
         },
@@ -17760,7 +17534,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53349",
+          "$$hashKey": "object:54256",
           "checked": true,
           "visualize": "true"
         },
@@ -17771,7 +17545,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53350",
+          "$$hashKey": "object:54257",
           "checked": true,
           "visualize": "true"
         },
@@ -17782,7 +17556,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53351",
+          "$$hashKey": "object:54258",
           "checked": true,
           "visualize": "true"
         },
@@ -17793,7 +17567,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53352",
+          "$$hashKey": "object:54259",
           "checked": true,
           "visualize": "true"
         },
@@ -17804,7 +17578,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53353",
+          "$$hashKey": "object:54260",
           "checked": true,
           "visualize": "true"
         },
@@ -17815,7 +17589,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53354",
+          "$$hashKey": "object:54261",
           "checked": true,
           "visualize": "true"
         },
@@ -17826,7 +17600,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53355",
+          "$$hashKey": "object:54262",
           "checked": true,
           "visualize": "true"
         },
@@ -17837,7 +17611,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53356",
+          "$$hashKey": "object:54263",
           "checked": true,
           "visualize": "true"
         },
@@ -17848,7 +17622,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53357",
+          "$$hashKey": "object:54264",
           "checked": true,
           "visualize": "true"
         },
@@ -17859,7 +17633,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53358",
+          "$$hashKey": "object:54265",
           "checked": true,
           "visualize": "true"
         },
@@ -17870,7 +17644,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53359",
+          "$$hashKey": "object:54266",
           "checked": true,
           "visualize": "true"
         },
@@ -17881,7 +17655,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53360",
+          "$$hashKey": "object:54267",
           "checked": true,
           "visualize": "true"
         },
@@ -17892,7 +17666,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53361",
+          "$$hashKey": "object:54268",
           "checked": true,
           "visualize": "true"
         },
@@ -17903,7 +17677,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53362",
+          "$$hashKey": "object:54269",
           "checked": true,
           "visualize": "true"
         },
@@ -17914,7 +17688,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53363",
+          "$$hashKey": "object:54270",
           "checked": true,
           "visualize": "true"
         },
@@ -17925,7 +17699,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53364",
+          "$$hashKey": "object:54271",
           "checked": true,
           "visualize": "true"
         },
@@ -17936,7 +17710,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53365",
+          "$$hashKey": "object:54272",
           "checked": true,
           "visualize": "true"
         },
@@ -17947,7 +17721,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53366",
+          "$$hashKey": "object:54273",
           "checked": true,
           "visualize": "true"
         },
@@ -17958,7 +17732,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53367",
+          "$$hashKey": "object:54274",
           "checked": true,
           "visualize": "true"
         },
@@ -17969,7 +17743,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53368",
+          "$$hashKey": "object:54275",
           "checked": true,
           "visualize": "true"
         },
@@ -17980,7 +17754,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53369",
+          "$$hashKey": "object:54276",
           "checked": true,
           "visualize": "true"
         },
@@ -17991,7 +17765,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53370",
+          "$$hashKey": "object:54277",
           "checked": true,
           "visualize": "true"
         },
@@ -18002,7 +17776,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53371",
+          "$$hashKey": "object:54278",
           "checked": true,
           "visualize": "true"
         },
@@ -18013,7 +17787,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53372",
+          "$$hashKey": "object:54279",
           "checked": true,
           "visualize": "true"
         },
@@ -18024,7 +17798,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53373",
+          "$$hashKey": "object:54280",
           "checked": true,
           "visualize": "true"
         },
@@ -18035,7 +17809,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53374",
+          "$$hashKey": "object:54281",
           "checked": true,
           "visualize": "true"
         },
@@ -18046,7 +17820,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53375",
+          "$$hashKey": "object:54282",
           "checked": true,
           "visualize": "true"
         },
@@ -18057,7 +17831,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53376",
+          "$$hashKey": "object:54283",
           "checked": true,
           "visualize": "true"
         },
@@ -18068,7 +17842,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53377",
+          "$$hashKey": "object:54284",
           "checked": true,
           "visualize": "true"
         },
@@ -18079,7 +17853,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53378",
+          "$$hashKey": "object:54285",
           "checked": true,
           "visualize": "true"
         },
@@ -18090,7 +17864,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53379",
+          "$$hashKey": "object:54286",
           "checked": true,
           "visualize": "true"
         },
@@ -18101,7 +17875,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53380",
+          "$$hashKey": "object:54287",
           "checked": true,
           "visualize": "true"
         },
@@ -18112,7 +17886,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:53381",
+          "$$hashKey": "object:54288",
           "checked": true,
           "visualize": "true"
         }
@@ -18137,15 +17911,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "12/10/2019",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.5107386512926242,
+      "instanceId": 0.377434629392601,
       "skip": false,
-      "$$hashKey": "object:49154",
+      "$$hashKey": "object:50974",
       "outputMeasure": true,
       "userDefinedOutputs": [],
       "analysisOutputs": [
@@ -18156,7 +17930,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53275",
+          "$$hashKey": "object:54180",
           "checked": true,
           "visualize": "true"
         },
@@ -18167,7 +17941,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53276",
+          "$$hashKey": "object:54181",
           "checked": true,
           "visualize": "true"
         },
@@ -18178,7 +17952,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53277",
+          "$$hashKey": "object:54182",
           "checked": true,
           "visualize": "true"
         },
@@ -18189,7 +17963,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53278",
+          "$$hashKey": "object:54183",
           "checked": true,
           "visualize": "true"
         },
@@ -18200,7 +17974,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53279",
+          "$$hashKey": "object:54184",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "total_site_wood_mbtu",
+          "display_name": "total_site_wood_mbtu",
+          "short_name": "total_site_wood_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:54185",
           "checked": true,
           "visualize": "true"
         },
@@ -18211,7 +17996,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53280",
+          "$$hashKey": "object:54186",
           "checked": true,
           "visualize": "true"
         },
@@ -18222,7 +18007,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53281",
+          "$$hashKey": "object:54187",
           "checked": true,
           "visualize": "true"
         },
@@ -18233,7 +18018,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53282",
+          "$$hashKey": "object:54188",
           "checked": true,
           "visualize": "true"
         },
@@ -18244,7 +18029,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53283",
+          "$$hashKey": "object:54189",
           "checked": true,
           "visualize": "true"
         },
@@ -18255,7 +18040,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53284",
+          "$$hashKey": "object:54190",
           "checked": true,
           "visualize": "true"
         },
@@ -18266,7 +18051,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53285",
+          "$$hashKey": "object:54191",
           "checked": true,
           "visualize": "true"
         },
@@ -18277,7 +18062,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53286",
+          "$$hashKey": "object:54192",
           "checked": true,
           "visualize": "true"
         },
@@ -18288,7 +18073,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53287",
+          "$$hashKey": "object:54193",
           "checked": true,
           "visualize": "true"
         },
@@ -18299,7 +18084,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53288",
+          "$$hashKey": "object:54194",
           "checked": true,
           "visualize": "true"
         },
@@ -18310,7 +18095,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53289",
+          "$$hashKey": "object:54195",
           "checked": true,
           "visualize": "true"
         },
@@ -18321,7 +18106,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53290",
+          "$$hashKey": "object:54196",
           "checked": true,
           "visualize": "true"
         },
@@ -18332,7 +18117,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53291",
+          "$$hashKey": "object:54197",
           "checked": true,
           "visualize": "true"
         },
@@ -18343,7 +18128,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53292",
+          "$$hashKey": "object:54198",
           "checked": true,
           "visualize": "true"
         },
@@ -18354,7 +18139,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53293",
+          "$$hashKey": "object:54199",
           "checked": true,
           "visualize": "true"
         },
@@ -18365,7 +18150,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53294",
+          "$$hashKey": "object:54200",
           "checked": true,
           "visualize": "true"
         },
@@ -18376,7 +18161,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53295",
+          "$$hashKey": "object:54201",
           "checked": true,
           "visualize": "true"
         },
@@ -18387,7 +18172,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53296",
+          "$$hashKey": "object:54202",
           "checked": true,
           "visualize": "true"
         },
@@ -18398,7 +18183,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53297",
+          "$$hashKey": "object:54203",
           "checked": true,
           "visualize": "true"
         },
@@ -18409,7 +18194,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53298",
+          "$$hashKey": "object:54204",
           "checked": true,
           "visualize": "true"
         },
@@ -18420,7 +18205,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53299",
+          "$$hashKey": "object:54205",
           "checked": true,
           "visualize": "true"
         },
@@ -18431,7 +18216,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53300",
+          "$$hashKey": "object:54206",
           "checked": true,
           "visualize": "true"
         },
@@ -18442,7 +18227,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53301",
+          "$$hashKey": "object:54207",
           "checked": true,
           "visualize": "true"
         },
@@ -18453,7 +18238,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53302",
+          "$$hashKey": "object:54208",
           "checked": true,
           "visualize": "true"
         },
@@ -18464,7 +18249,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53303",
+          "$$hashKey": "object:54209",
           "checked": true,
           "visualize": "true"
         },
@@ -18475,7 +18260,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53304",
+          "$$hashKey": "object:54210",
           "checked": true,
           "visualize": "true"
         },
@@ -18486,7 +18271,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53305",
+          "$$hashKey": "object:54211",
           "checked": true,
           "visualize": "true"
         },
@@ -18497,7 +18282,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53306",
+          "$$hashKey": "object:54212",
           "checked": true,
           "visualize": "true"
         },
@@ -18508,7 +18293,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53307",
+          "$$hashKey": "object:54213",
           "checked": true,
           "visualize": "true"
         },
@@ -18519,7 +18304,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53308",
+          "$$hashKey": "object:54214",
           "checked": true,
           "visualize": "true"
         },
@@ -18530,7 +18315,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53309",
+          "$$hashKey": "object:54215",
           "checked": true,
           "visualize": "true"
         },
@@ -18541,7 +18326,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53310",
+          "$$hashKey": "object:54216",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "wood_heating_mbtu",
+          "display_name": "wood_heating_mbtu",
+          "short_name": "wood_heating_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:54217",
           "checked": true,
           "visualize": "true"
         },
@@ -18552,7 +18348,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53311",
+          "$$hashKey": "object:54218",
           "checked": true,
           "visualize": "true"
         },
@@ -18563,7 +18359,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53312",
+          "$$hashKey": "object:54219",
           "checked": true,
           "visualize": "true"
         },
@@ -18574,7 +18370,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53313",
+          "$$hashKey": "object:54220",
           "checked": true,
           "visualize": "true"
         },
@@ -18585,7 +18381,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53314",
+          "$$hashKey": "object:54221",
           "checked": true,
           "visualize": "true"
         },
@@ -18596,7 +18392,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53315",
+          "$$hashKey": "object:54222",
           "checked": true,
           "visualize": "true"
         },
@@ -18607,7 +18403,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53316",
+          "$$hashKey": "object:54223",
           "checked": true,
           "visualize": "true"
         },
@@ -18618,7 +18414,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53317",
+          "$$hashKey": "object:54224",
           "checked": true,
           "visualize": "true"
         },
@@ -18629,7 +18425,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53318",
+          "$$hashKey": "object:54225",
           "checked": true,
           "visualize": "true"
         },
@@ -18640,7 +18436,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53319",
+          "$$hashKey": "object:54226",
           "checked": true,
           "visualize": "true"
         },
@@ -18651,7 +18447,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53320",
+          "$$hashKey": "object:54227",
           "checked": true,
           "visualize": "true"
         },
@@ -18662,7 +18458,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53321",
+          "$$hashKey": "object:54228",
           "checked": true,
           "visualize": "true"
         },
@@ -18673,7 +18469,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53322",
+          "$$hashKey": "object:54229",
           "checked": true,
           "visualize": "true"
         },
@@ -18684,7 +18480,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53323",
+          "$$hashKey": "object:54230",
           "checked": true,
           "visualize": "true"
         },
@@ -18695,7 +18491,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53324",
+          "$$hashKey": "object:54231",
           "checked": true,
           "visualize": "true"
         },
@@ -18706,7 +18502,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53325",
+          "$$hashKey": "object:54232",
           "checked": true,
           "visualize": "true"
         },
@@ -18717,7 +18513,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53326",
+          "$$hashKey": "object:54233",
           "checked": true,
           "visualize": "true"
         },
@@ -18728,7 +18524,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53327",
+          "$$hashKey": "object:54234",
           "checked": true,
           "visualize": "true"
         },
@@ -18739,7 +18535,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53328",
+          "$$hashKey": "object:54235",
           "checked": true,
           "visualize": "true"
         },
@@ -18750,7 +18546,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53329",
+          "$$hashKey": "object:54236",
           "checked": true,
           "visualize": "true"
         },
@@ -18761,7 +18557,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53330",
+          "$$hashKey": "object:54237",
           "checked": true,
           "visualize": "true"
         },
@@ -18772,7 +18568,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53331",
+          "$$hashKey": "object:54238",
           "checked": true,
           "visualize": "true"
         },
@@ -18783,7 +18579,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53332",
+          "$$hashKey": "object:54239",
           "checked": true,
           "visualize": "true"
         },
@@ -18794,7 +18590,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53333",
+          "$$hashKey": "object:54240",
           "checked": true,
           "visualize": "true"
         },
@@ -18805,7 +18601,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53334",
+          "$$hashKey": "object:54241",
           "checked": true,
           "visualize": "true"
         },
@@ -18816,7 +18612,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53335",
+          "$$hashKey": "object:54242",
           "checked": true,
           "visualize": "true"
         },
@@ -18827,7 +18623,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53336",
+          "$$hashKey": "object:54243",
           "checked": true,
           "visualize": "true"
         },
@@ -18838,7 +18634,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53337",
+          "$$hashKey": "object:54244",
           "checked": true,
           "visualize": "true"
         },
@@ -18849,7 +18645,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53338",
+          "$$hashKey": "object:54245",
           "checked": true,
           "visualize": "true"
         },
@@ -18860,7 +18656,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53339",
+          "$$hashKey": "object:54246",
           "checked": true,
           "visualize": "true"
         },
@@ -18871,7 +18667,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53340",
+          "$$hashKey": "object:54247",
           "checked": true,
           "visualize": "true"
         },
@@ -18882,7 +18678,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53341",
+          "$$hashKey": "object:54248",
           "checked": true,
           "visualize": "true"
         },
@@ -18893,7 +18689,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53342",
+          "$$hashKey": "object:54249",
           "checked": true,
           "visualize": "true"
         },
@@ -18904,7 +18700,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53343",
+          "$$hashKey": "object:54250",
           "checked": true,
           "visualize": "true"
         },
@@ -18915,7 +18711,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53344",
+          "$$hashKey": "object:54251",
           "checked": true,
           "visualize": "true"
         },
@@ -18926,7 +18722,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53345",
+          "$$hashKey": "object:54252",
           "checked": true,
           "visualize": "true"
         },
@@ -18937,7 +18733,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53346",
+          "$$hashKey": "object:54253",
           "checked": true,
           "visualize": "true"
         },
@@ -18948,7 +18744,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53347",
+          "$$hashKey": "object:54254",
           "checked": true,
           "visualize": "true"
         },
@@ -18959,7 +18755,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53348",
+          "$$hashKey": "object:54255",
           "checked": true,
           "visualize": "true"
         },
@@ -18970,7 +18766,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53349",
+          "$$hashKey": "object:54256",
           "checked": true,
           "visualize": "true"
         },
@@ -18981,7 +18777,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53350",
+          "$$hashKey": "object:54257",
           "checked": true,
           "visualize": "true"
         },
@@ -18992,7 +18788,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53351",
+          "$$hashKey": "object:54258",
           "checked": true,
           "visualize": "true"
         },
@@ -19003,7 +18799,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53352",
+          "$$hashKey": "object:54259",
           "checked": true,
           "visualize": "true"
         },
@@ -19014,7 +18810,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53353",
+          "$$hashKey": "object:54260",
           "checked": true,
           "visualize": "true"
         },
@@ -19025,7 +18821,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53354",
+          "$$hashKey": "object:54261",
           "checked": true,
           "visualize": "true"
         },
@@ -19036,7 +18832,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53355",
+          "$$hashKey": "object:54262",
           "checked": true,
           "visualize": "true"
         },
@@ -19047,7 +18843,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53356",
+          "$$hashKey": "object:54263",
           "checked": true,
           "visualize": "true"
         },
@@ -19058,7 +18854,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53357",
+          "$$hashKey": "object:54264",
           "checked": true,
           "visualize": "true"
         },
@@ -19069,7 +18865,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53358",
+          "$$hashKey": "object:54265",
           "checked": true,
           "visualize": "true"
         },
@@ -19080,7 +18876,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53359",
+          "$$hashKey": "object:54266",
           "checked": true,
           "visualize": "true"
         },
@@ -19091,7 +18887,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53360",
+          "$$hashKey": "object:54267",
           "checked": true,
           "visualize": "true"
         },
@@ -19102,7 +18898,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53361",
+          "$$hashKey": "object:54268",
           "checked": true,
           "visualize": "true"
         },
@@ -19113,7 +18909,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53362",
+          "$$hashKey": "object:54269",
           "checked": true,
           "visualize": "true"
         },
@@ -19124,7 +18920,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53363",
+          "$$hashKey": "object:54270",
           "checked": true,
           "visualize": "true"
         },
@@ -19135,7 +18931,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53364",
+          "$$hashKey": "object:54271",
           "checked": true,
           "visualize": "true"
         },
@@ -19146,7 +18942,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53365",
+          "$$hashKey": "object:54272",
           "checked": true,
           "visualize": "true"
         },
@@ -19157,7 +18953,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53366",
+          "$$hashKey": "object:54273",
           "checked": true,
           "visualize": "true"
         },
@@ -19168,7 +18964,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53367",
+          "$$hashKey": "object:54274",
           "checked": true,
           "visualize": "true"
         },
@@ -19179,7 +18975,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53368",
+          "$$hashKey": "object:54275",
           "checked": true,
           "visualize": "true"
         },
@@ -19190,7 +18986,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53369",
+          "$$hashKey": "object:54276",
           "checked": true,
           "visualize": "true"
         },
@@ -19201,7 +18997,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53370",
+          "$$hashKey": "object:54277",
           "checked": true,
           "visualize": "true"
         },
@@ -19212,7 +19008,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53371",
+          "$$hashKey": "object:54278",
           "checked": true,
           "visualize": "true"
         },
@@ -19223,7 +19019,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53372",
+          "$$hashKey": "object:54279",
           "checked": true,
           "visualize": "true"
         },
@@ -19234,7 +19030,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53373",
+          "$$hashKey": "object:54280",
           "checked": true,
           "visualize": "true"
         },
@@ -19245,7 +19041,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53374",
+          "$$hashKey": "object:54281",
           "checked": true,
           "visualize": "true"
         },
@@ -19256,7 +19052,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53375",
+          "$$hashKey": "object:54282",
           "checked": true,
           "visualize": "true"
         },
@@ -19267,7 +19063,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53376",
+          "$$hashKey": "object:54283",
           "checked": true,
           "visualize": "true"
         },
@@ -19278,7 +19074,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53377",
+          "$$hashKey": "object:54284",
           "checked": true,
           "visualize": "true"
         },
@@ -19289,7 +19085,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53378",
+          "$$hashKey": "object:54285",
           "checked": true,
           "visualize": "true"
         },
@@ -19300,7 +19096,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53379",
+          "$$hashKey": "object:54286",
           "checked": true,
           "visualize": "true"
         },
@@ -19311,7 +19107,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:53380",
+          "$$hashKey": "object:54287",
           "checked": true,
           "visualize": "true"
         },
@@ -19322,7 +19118,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:53381",
+          "$$hashKey": "object:54288",
           "checked": true,
           "visualize": "true"
         }
@@ -19331,12 +19127,12 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\TimeseriesCSVExport",
       "name": "timeseries_csv_export",
-      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_multifamily_beta\\measures\\TimeseriesCSVExport",
+      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/TimeseriesCSVExport",
       "uid": "2a3442c1-944d-4e91-9e11-11e0cf368c64",
       "uuid": "{2a3442c1-944d-4e91-9e11-11e0cf368c64}",
-      "version_id": "64696f29-6d80-4418-b20d-61f5bdff5495",
-      "version_uuid": "{64696f29-6d80-4418-b20d-61f5bdff5495}",
-      "version_modified": "20191210T220251Z",
+      "version_id": "cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03",
+      "version_uuid": "{cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03}",
+      "version_modified": "20200123T180929Z",
       "xml_checksum": "15BF4E57",
       "display_name": "Timeseries CSV Export",
       "class_name": "TimeseriesCSVExport",
@@ -19391,7 +19187,7 @@
             "stdDev": "Hourly",
             "default_value": "Hourly"
           },
-          "$$hashKey": "object:34202"
+          "$$hashKey": "object:51032"
         },
         {
           "name": "include_enduse_subcategories",
@@ -19415,7 +19211,7 @@
             "stdDev": false,
             "default_value": false
           },
-          "$$hashKey": "object:34203"
+          "$$hashKey": "object:51033"
         },
         {
           "name": "output_variables",
@@ -19438,7 +19234,7 @@
             "stdDev": "",
             "default_value": ""
           },
-          "$$hashKey": "object:34204"
+          "$$hashKey": "object:51034"
         }
       ],
       "edit": "",
@@ -19448,15 +19244,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "12/10/2019",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.32277842249920763,
+      "instanceId": 0.45789139111430743,
       "skip": false,
-      "$$hashKey": "object:34159",
+      "$$hashKey": "object:50973",
       "outputMeasure": false
     },
     {
@@ -19501,7 +19297,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.8752069568152259,
+      "instanceId": 0.7100456531549337,
       "skip": false,
       "$$hashKey": "object:663249",
       "outputMeasure": false

--- a/project_singlefamilydetached/measures/BuildingCharacteristicsReport/measure.xml
+++ b/project_singlefamilydetached/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>da2102f5-b790-465d-9394-f012fe4ddad3</version_id>
-  <version_modified>20200118T172411Z</version_modified>
+  <version_id>1f44b04d-9e14-4f5d-8c10-7240262b845c</version_id>
+  <version_modified>20200123T175727Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -906,7 +906,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CE447A1E</checksum>
+      <checksum>F5F682BD</checksum>
     </file>
   </files>
 </measure>

--- a/project_singlefamilydetached/measures/SimulationOutputReport/measure.rb
+++ b/project_singlefamilydetached/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation outputs of interest."
+    return "Reports simulation ou tputs of interest."
   end
 
   def num_options
@@ -66,6 +66,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "total_site_natural_gas_therm",
       "total_site_fuel_oil_mbtu",
       "total_site_propane_mbtu",
+      "total_site_wood_mbtu",
       "net_site_energy_mbtu", # Incorporates PV
       "net_site_electricity_kwh", # Incorporates PV
       "electricity_heating_kwh",
@@ -97,6 +98,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "propane_central_system_heating_mbtu",
       "propane_interior_equipment_mbtu",
       "propane_water_systems_mbtu",
+      "wood_heating_mbtu",
       "hours_heating_setpoint_not_met",
       "hours_cooling_setpoint_not_met",
       "hvac_cooling_capacity_w",
@@ -191,6 +193,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
     hours_setpoint_not_met = output_meters.hours_setpoint_not_met(sqlFile)
 
     # ELECTRICITY
@@ -290,12 +293,18 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "propane_interior_equipment_mbtu", propane.interior_equipment[0], "GJ", other_fuel_site_units)
     report_sim_output(runner, "propane_water_systems_mbtu", propane.water_systems[0], "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_sim_output(runner, "total_site_wood_mbtu", wood.total_end_uses[0], "GJ", other_fuel_site_units)
+    report_sim_output(runner, "wood_heating_mbtu", wood.heating[0], "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses[0] +
                       natural_gas.total_end_uses[0] +
                       fuel_oil.total_end_uses[0] +
-                      propane.total_end_uses[0]
+                      propane.total_end_uses[0] +
+                      wood.total_end_uses[0]
 
     if units.length == total_units_represented
       err = totalSiteEnergy - sqlFile.totalSiteEnergy.get

--- a/project_singlefamilydetached/measures/SimulationOutputReport/measure.rb
+++ b/project_singlefamilydetached/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation ou tputs of interest."
+    return "Reports simulation outputs of interest."
   end
 
   def num_options

--- a/project_singlefamilydetached/measures/SimulationOutputReport/measure.xml
+++ b/project_singlefamilydetached/measures/SimulationOutputReport/measure.xml
@@ -2,12 +2,12 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>2992ab1b-5569-465c-a32b-c622a453a3cb</version_id>
+  <version_modified>20200123T175728Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
-  <description>Reports simulation outputs of interest.</description>
+  <description>Reports simulation ou tputs of interest.</description>
   <modeler_description>Change me</modeler_description>
   <arguments/>
   <outputs>
@@ -43,6 +43,13 @@
       <name>total_site_propane_mbtu</name>
       <display_name>total_site_propane_mbtu</display_name>
       <short_name>total_site_propane_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>total_site_wood_mbtu</name>
+      <display_name>total_site_wood_mbtu</display_name>
+      <short_name>total_site_wood_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -260,6 +267,13 @@
       <name>propane_water_systems_mbtu</name>
       <display_name>propane_water_systems_mbtu</display_name>
       <short_name>propane_water_systems_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>wood_heating_mbtu</name>
+      <display_name>wood_heating_mbtu</display_name>
+      <short_name>wood_heating_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -793,7 +807,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0EBF3BC0</checksum>
+      <checksum>11288408</checksum>
     </file>
   </files>
 </measure>

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.rb
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.rb
@@ -192,6 +192,7 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
 
     # ELECTRICITY
 
@@ -239,12 +240,18 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "propane_interior_equipment_mbtu", propane.interior_equipment, "GJ", other_fuel_site_units)
     report_ts_output(runner, timeseries, "propane_water_systems_mbtu", propane.water_systems, "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_ts_output(runner, timeseries, "total_site_wood_mbtu", wood.total_end_uses, "GJ", other_fuel_site_units)
+    report_ts_output(runner, timeseries, "wood_heating_mbtu", wood.heating, "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses +
                       natural_gas.total_end_uses +
                       fuel_oil.total_end_uses +
-                      propane.total_end_uses
+                      propane.total_end_uses +
+                      wood.total_end_uses
 
     report_ts_output(runner, timeseries, "total_site_energy_mbtu", totalSiteEnergy, "GJ", total_site_units)
     report_ts_output(runner, timeseries, "net_site_energy_mbtu", totalSiteEnergy - electricity.photovoltaics, "GJ", total_site_units)

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.xml
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03</version_id>
+  <version_modified>20200123T180929Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,6 +79,12 @@
   </attributes>
   <files>
     <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3A9D58E2</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -87,13 +93,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6C92E878</checksum>
-    </file>
-    <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F8C982FF</checksum>
+      <checksum>731388DC</checksum>
     </file>
   </files>
 </measure>

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -13,7 +13,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Timestep"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Zone Mean Air Temperature, Site Outdoor Air Drybulb Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 34 + 28 + 5 }
+    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 36 + 28 + 5 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2012.epw", num_output_requests)
   end
 

--- a/project_singlefamilydetached/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_singlefamilydetached/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -73,7 +73,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Electric Equipment Electric Power, Zone Air Heat Balance Internal Convective Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 9 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 9 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -106,7 +106,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Daily"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Cooling Coil Runtime Fraction, Unitary System Ancillary Electric Power, System Node Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 1 }
     _test_measure("MF_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_singlefamilydetached/pat.json
+++ b/project_singlefamilydetached/pat.json
@@ -312,7 +312,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.7211989782422992,
+      "instanceId": 0.2419115328657424,
       "skip": false,
       "$$hashKey": "object:11247",
       "outputMeasure": false
@@ -320,7 +320,7 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildExistingModel",
       "name": "build_existing_model",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildExistingModel",
       "uid": "dedf59bb-3b88-4f16-8755-2c1ff5519cbf",
       "uuid": "{dedf59bb-3b88-4f16-8755-2c1ff5519cbf}",
       "version_id": "ddb1178a-cb38-492a-84d7-534fd5d25142",
@@ -494,7 +494,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.17194209787015025,
+      "instanceId": 0.6117515625760896,
       "skip": false,
       "$$hashKey": "object:32367",
       "showWarningText": false,
@@ -7316,7 +7316,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.3885488293605124,
+      "instanceId": 0.5837618745500481,
       "skip": false,
       "$$hashKey": "object:34633",
       "showWarningText": false,
@@ -14138,21 +14138,21 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.4844552000128699,
+      "instanceId": 0.2481865328166455,
       "skip": false,
       "$$hashKey": "object:40798",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\BuildingCharacteristicsReport",
+      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "name": "building_characteristics_report",
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
-      "version_id": "da2102f5-b790-465d-9394-f012fe4ddad3",
-      "version_uuid": "{da2102f5-b790-465d-9394-f012fe4ddad3}",
-      "version_modified": "20200118T172411Z",
+      "version_id": "1f44b04d-9e14-4f5d-8c10-7240262b845c",
+      "version_uuid": "{1f44b04d-9e14-4f5d-8c10-7240262b845c}",
+      "version_modified": "20200123T175727Z",
       "xml_checksum": "2EA103AF",
       "display_name": "Building Characteristics Report",
       "class_name": "BuildingCharacteristicsReport",
@@ -14167,9 +14167,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34128",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_heating_region",
@@ -14178,9 +14176,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34129",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_cooling_region",
@@ -14189,9 +14185,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34130",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location",
@@ -14200,9 +14194,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34131",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_weather_filename",
@@ -14211,9 +14203,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34132",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_weather_year",
@@ -14222,9 +14212,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34133",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "vintage",
@@ -14233,9 +14221,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34134",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "vintage_acs",
@@ -14244,9 +14230,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34135",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_fuel",
@@ -14255,9 +14239,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34136",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "usage_level",
@@ -14266,9 +14248,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34137",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_attic_type",
@@ -14277,9 +14257,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34138",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_type_recs",
@@ -14288,9 +14266,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34139",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_type_acs",
@@ -14299,9 +14275,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34140",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_number_units",
@@ -14310,9 +14284,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34141",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_mf",
@@ -14321,9 +14293,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34142",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_sfa",
@@ -14332,9 +14302,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34143",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_hl",
@@ -14343,9 +14311,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34144",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_foundation_type",
@@ -14354,9 +14320,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34145",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_heated_basement",
@@ -14365,9 +14329,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34146",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_wall_type",
@@ -14376,9 +14338,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34147",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_stories",
@@ -14387,9 +14347,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34148",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_garage",
@@ -14398,9 +14356,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34149",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_house_size",
@@ -14409,9 +14365,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34150",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "bedrooms",
@@ -14420,9 +14374,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34151",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "corridor",
@@ -14431,9 +14383,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34152",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_number_units_acs_bins",
@@ -14442,9 +14392,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34153",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_unit_stories_sf",
@@ -14453,9 +14401,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34154",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_unit_stories_mf",
@@ -14464,9 +14410,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34155",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "occupants",
@@ -14475,9 +14419,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34156",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "orientation",
@@ -14486,9 +14428,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34157",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "eaves",
@@ -14497,9 +14437,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34158",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "door_area",
@@ -14508,9 +14446,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34159",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "window_areas",
@@ -14519,9 +14455,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34160",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "overhangs",
@@ -14530,9 +14464,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34161",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "neighbors",
@@ -14541,9 +14473,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34162",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_unfinished_attic",
@@ -14552,9 +14482,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34163",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_finished_roof",
@@ -14563,9 +14491,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34164",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "radiant_barrier_unfinished_attic",
@@ -14574,9 +14500,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34165",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "roof_material",
@@ -14585,9 +14509,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34166",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_slab",
@@ -14596,9 +14518,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34167",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_crawlspace",
@@ -14607,9 +14527,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34168",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_unfinished_basement",
@@ -14618,9 +14536,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34169",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_finished_basement",
@@ -14629,9 +14545,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34170",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_pier_beam",
@@ -14640,9 +14554,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34171",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_interzonal_floor",
@@ -14651,9 +14563,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34172",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_wall",
@@ -14662,9 +14572,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34173",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "interior_shading",
@@ -14673,9 +14581,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34174",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "windows",
@@ -14684,9 +14590,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34175",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "doors",
@@ -14695,9 +14599,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34176",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "water_heater",
@@ -14706,9 +14608,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34177",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hot_water_fixtures",
@@ -14717,9 +14617,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34178",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hot_water_distribution",
@@ -14728,9 +14626,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34179",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "solar_hot_water",
@@ -14739,9 +14635,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34180",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_is_shared",
@@ -14750,9 +14644,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34181",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_electricity",
@@ -14761,9 +14653,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34182",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_natural_gas",
@@ -14772,9 +14662,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34183",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_propane",
@@ -14783,9 +14671,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34184",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_fuel_oil",
@@ -14794,9 +14680,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34185",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_other_fuel",
@@ -14805,9 +14689,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34186",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_none",
@@ -14816,9 +14698,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34187",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_is_heat_pump",
@@ -14827,9 +14707,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34188",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heat_pump",
@@ -14838,9 +14716,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34189",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_electricity",
@@ -14849,9 +14725,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34190",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_natural_gas",
@@ -14860,9 +14734,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34191",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_propane",
@@ -14871,9 +14743,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34192",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_fuel_oil",
@@ -14882,9 +14752,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34193",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_wood",
@@ -14893,9 +14761,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34194",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_other_fuel",
@@ -14904,9 +14770,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34195",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_none",
@@ -14915,9 +14779,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34196",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_cooling",
@@ -14926,9 +14788,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34197",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_cooling_type",
@@ -14937,9 +14797,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34198",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint",
@@ -14948,9 +14806,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34199",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint",
@@ -14959,9 +14815,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34200",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_has_offset",
@@ -14970,9 +14824,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34201",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_has_offset",
@@ -14981,9 +14833,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34202",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_offset_magnitude",
@@ -14992,9 +14842,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34203",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_offset_magnitude",
@@ -15003,9 +14851,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34204",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_offset_period",
@@ -15014,9 +14860,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34205",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_offset_period",
@@ -15025,9 +14869,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34206",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "setpoint_demand_response",
@@ -15036,9 +14878,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34207",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "ceiling_fan",
@@ -15047,9 +14887,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34208",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "dehumidifier",
@@ -15058,9 +14896,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34209",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "refrigerator",
@@ -15069,9 +14905,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34210",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "refrigeration_schedule",
@@ -15080,9 +14914,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34211",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooking_range",
@@ -15091,9 +14923,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34212",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooking_range_schedule",
@@ -15102,9 +14932,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34213",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "dishwasher",
@@ -15113,9 +14941,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34214",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "clothes_washer",
@@ -15124,9 +14950,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34215",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "clothes_dryer",
@@ -15135,9 +14959,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34216",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting",
@@ -15146,9 +14968,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34217",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting_interior_use",
@@ -15157,9 +14977,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34218",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting_other_use",
@@ -15168,9 +14986,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34219",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "holiday_lighting",
@@ -15179,9 +14995,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34220",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "plug_loads",
@@ -15190,9 +15004,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34221",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "plug_loads_schedule",
@@ -15201,9 +15013,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34222",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "electric_vehicle",
@@ -15212,9 +15022,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34223",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_extra_refrigerator",
@@ -15223,9 +15031,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34224",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_freezer",
@@ -15234,9 +15040,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34225",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_fireplace",
@@ -15245,9 +15049,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34226",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_grill",
@@ -15256,9 +15058,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34227",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_lighting",
@@ -15267,9 +15067,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34228",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_hot_tub_spa",
@@ -15278,9 +15076,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34229",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool",
@@ -15289,9 +15085,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34230",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_heater",
@@ -15300,9 +15094,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34231",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_pump",
@@ -15311,9 +15103,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34232",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_schedule",
@@ -15322,9 +15112,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34233",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_well_pump",
@@ -15333,9 +15121,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34234",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "ducts",
@@ -15344,9 +15130,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34235",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "infiltration",
@@ -15355,9 +15139,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34236",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "natural_ventilation",
@@ -15366,9 +15148,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34237",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "mechanical_ventilation",
@@ -15377,9 +15157,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34238",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "bathroom_spot_vent_hour",
@@ -15388,9 +15166,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34239",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "range_spot_vent_hour",
@@ -15399,9 +15175,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34240",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "pv",
@@ -15410,9 +15184,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34241",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "days_shifted",
@@ -15421,9 +15193,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34242",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_perimeter_footprint_ratio",
@@ -15432,9 +15202,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34243",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_city",
@@ -15443,9 +15211,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34244",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_state",
@@ -15454,9 +15220,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34245",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_latitude",
@@ -15465,9 +15229,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34246",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_longitude",
@@ -15476,9 +15238,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34247",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "climate_zone_ba",
@@ -15487,9 +15247,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34248",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "climate_zone_iecc",
@@ -15498,9 +15256,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34249",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "units_represented",
@@ -15509,9 +15265,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34250",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "units_modeled",
@@ -15520,9 +15274,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34251",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         }
       ],
       "attributes": [
@@ -15545,13 +15297,13 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "1/18/2020",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.8467135739920624,
+      "instanceId": 0.16344863243825247,
       "skip": false,
       "$$hashKey": "object:33646",
       "outputMeasure": true,
@@ -16929,13 +16681,13 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/SimulationOutputReport",
       "uid": "fc337100-8634-404e-8966-01243d292a79",
       "uuid": "{fc337100-8634-404e-8966-01243d292a79}",
-      "version_id": "452c3c75-928b-4c49-93f5-dc319088b009",
-      "version_uuid": "{452c3c75-928b-4c49-93f5-dc319088b009}",
-      "version_modified": "20191210T220251Z",
+      "version_id": "2992ab1b-5569-465c-a32b-c622a453a3cb",
+      "version_uuid": "{2992ab1b-5569-465c-a32b-c622a453a3cb}",
+      "version_modified": "20200123T175728Z",
       "xml_checksum": "2C8A3EEF",
       "display_name": "Simulation Output Report",
       "class_name": "SimulationOutputReport",
-      "description": "Reports simulation outputs of interest.",
+      "description": "Reports simulation ou tputs of interest.",
       "modeler_description": "Change me",
       "tags": "Reporting.QAQC",
       "outputs": [
@@ -16946,7 +16698,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37956",
+          "$$hashKey": "object:36476",
           "checked": true,
           "visualize": "true"
         },
@@ -16957,7 +16709,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37957",
+          "$$hashKey": "object:36477",
           "checked": true,
           "visualize": "true"
         },
@@ -16968,7 +16720,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37958",
+          "$$hashKey": "object:36478",
           "checked": true,
           "visualize": "true"
         },
@@ -16979,7 +16731,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37959",
+          "$$hashKey": "object:36479",
           "checked": true,
           "visualize": "true"
         },
@@ -16990,7 +16742,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37960",
+          "$$hashKey": "object:36480",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "total_site_wood_mbtu",
+          "display_name": "total_site_wood_mbtu",
+          "short_name": "total_site_wood_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36481",
           "checked": true,
           "visualize": "true"
         },
@@ -17001,7 +16764,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37961",
+          "$$hashKey": "object:36482",
           "checked": true,
           "visualize": "true"
         },
@@ -17012,7 +16775,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37962",
+          "$$hashKey": "object:36483",
           "checked": true,
           "visualize": "true"
         },
@@ -17023,7 +16786,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37963",
+          "$$hashKey": "object:36484",
           "checked": true,
           "visualize": "true"
         },
@@ -17034,7 +16797,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37964",
+          "$$hashKey": "object:36485",
           "checked": true,
           "visualize": "true"
         },
@@ -17045,7 +16808,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37965",
+          "$$hashKey": "object:36486",
           "checked": true,
           "visualize": "true"
         },
@@ -17056,7 +16819,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37966",
+          "$$hashKey": "object:36487",
           "checked": true,
           "visualize": "true"
         },
@@ -17067,7 +16830,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37967",
+          "$$hashKey": "object:36488",
           "checked": true,
           "visualize": "true"
         },
@@ -17078,7 +16841,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37968",
+          "$$hashKey": "object:36489",
           "checked": true,
           "visualize": "true"
         },
@@ -17089,7 +16852,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37969",
+          "$$hashKey": "object:36490",
           "checked": true,
           "visualize": "true"
         },
@@ -17100,7 +16863,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37970",
+          "$$hashKey": "object:36491",
           "checked": true,
           "visualize": "true"
         },
@@ -17111,7 +16874,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37971",
+          "$$hashKey": "object:36492",
           "checked": true,
           "visualize": "true"
         },
@@ -17122,7 +16885,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37972",
+          "$$hashKey": "object:36493",
           "checked": true,
           "visualize": "true"
         },
@@ -17133,7 +16896,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37973",
+          "$$hashKey": "object:36494",
           "checked": true,
           "visualize": "true"
         },
@@ -17144,7 +16907,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37974",
+          "$$hashKey": "object:36495",
           "checked": true,
           "visualize": "true"
         },
@@ -17155,7 +16918,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37975",
+          "$$hashKey": "object:36496",
           "checked": true,
           "visualize": "true"
         },
@@ -17166,7 +16929,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37976",
+          "$$hashKey": "object:36497",
           "checked": true,
           "visualize": "true"
         },
@@ -17177,7 +16940,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37977",
+          "$$hashKey": "object:36498",
           "checked": true,
           "visualize": "true"
         },
@@ -17188,7 +16951,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37978",
+          "$$hashKey": "object:36499",
           "checked": true,
           "visualize": "true"
         },
@@ -17199,7 +16962,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37979",
+          "$$hashKey": "object:36500",
           "checked": true,
           "visualize": "true"
         },
@@ -17210,7 +16973,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37980",
+          "$$hashKey": "object:36501",
           "checked": true,
           "visualize": "true"
         },
@@ -17221,7 +16984,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37981",
+          "$$hashKey": "object:36502",
           "checked": true,
           "visualize": "true"
         },
@@ -17232,7 +16995,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37982",
+          "$$hashKey": "object:36503",
           "checked": true,
           "visualize": "true"
         },
@@ -17243,7 +17006,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37983",
+          "$$hashKey": "object:36504",
           "checked": true,
           "visualize": "true"
         },
@@ -17254,7 +17017,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37984",
+          "$$hashKey": "object:36505",
           "checked": true,
           "visualize": "true"
         },
@@ -17265,7 +17028,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37985",
+          "$$hashKey": "object:36506",
           "checked": true,
           "visualize": "true"
         },
@@ -17276,7 +17039,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37986",
+          "$$hashKey": "object:36507",
           "checked": true,
           "visualize": "true"
         },
@@ -17287,7 +17050,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37987",
+          "$$hashKey": "object:36508",
           "checked": true,
           "visualize": "true"
         },
@@ -17298,7 +17061,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37988",
+          "$$hashKey": "object:36509",
           "checked": true,
           "visualize": "true"
         },
@@ -17309,7 +17072,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37989",
+          "$$hashKey": "object:36510",
           "checked": true,
           "visualize": "true"
         },
@@ -17320,7 +17083,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37990",
+          "$$hashKey": "object:36511",
           "checked": true,
           "visualize": "true"
         },
@@ -17331,7 +17094,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37991",
+          "$$hashKey": "object:36512",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "wood_heating_mbtu",
+          "display_name": "wood_heating_mbtu",
+          "short_name": "wood_heating_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36513",
           "checked": true,
           "visualize": "true"
         },
@@ -17342,7 +17116,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37992",
+          "$$hashKey": "object:36514",
           "checked": true,
           "visualize": "true"
         },
@@ -17353,7 +17127,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37993",
+          "$$hashKey": "object:36515",
           "checked": true,
           "visualize": "true"
         },
@@ -17364,7 +17138,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37994",
+          "$$hashKey": "object:36516",
           "checked": true,
           "visualize": "true"
         },
@@ -17375,7 +17149,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37995",
+          "$$hashKey": "object:36517",
           "checked": true,
           "visualize": "true"
         },
@@ -17386,7 +17160,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37996",
+          "$$hashKey": "object:36518",
           "checked": true,
           "visualize": "true"
         },
@@ -17397,7 +17171,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37997",
+          "$$hashKey": "object:36519",
           "checked": true,
           "visualize": "true"
         },
@@ -17408,7 +17182,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37998",
+          "$$hashKey": "object:36520",
           "checked": true,
           "visualize": "true"
         },
@@ -17419,7 +17193,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37999",
+          "$$hashKey": "object:36521",
           "checked": true,
           "visualize": "true"
         },
@@ -17430,7 +17204,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38000",
+          "$$hashKey": "object:36522",
           "checked": true,
           "visualize": "true"
         },
@@ -17441,7 +17215,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38001",
+          "$$hashKey": "object:36523",
           "checked": true,
           "visualize": "true"
         },
@@ -17452,7 +17226,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38002",
+          "$$hashKey": "object:36524",
           "checked": true,
           "visualize": "true"
         },
@@ -17463,7 +17237,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38003",
+          "$$hashKey": "object:36525",
           "checked": true,
           "visualize": "true"
         },
@@ -17474,7 +17248,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38004",
+          "$$hashKey": "object:36526",
           "checked": true,
           "visualize": "true"
         },
@@ -17485,7 +17259,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38005",
+          "$$hashKey": "object:36527",
           "checked": true,
           "visualize": "true"
         },
@@ -17496,7 +17270,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38006",
+          "$$hashKey": "object:36528",
           "checked": true,
           "visualize": "true"
         },
@@ -17507,7 +17281,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38007",
+          "$$hashKey": "object:36529",
           "checked": true,
           "visualize": "true"
         },
@@ -17518,7 +17292,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38008",
+          "$$hashKey": "object:36530",
           "checked": true,
           "visualize": "true"
         },
@@ -17529,7 +17303,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38009",
+          "$$hashKey": "object:36531",
           "checked": true,
           "visualize": "true"
         },
@@ -17540,7 +17314,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38010",
+          "$$hashKey": "object:36532",
           "checked": true,
           "visualize": "true"
         },
@@ -17551,7 +17325,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38011",
+          "$$hashKey": "object:36533",
           "checked": true,
           "visualize": "true"
         },
@@ -17562,7 +17336,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38012",
+          "$$hashKey": "object:36534",
           "checked": true,
           "visualize": "true"
         },
@@ -17573,7 +17347,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38013",
+          "$$hashKey": "object:36535",
           "checked": true,
           "visualize": "true"
         },
@@ -17584,7 +17358,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38014",
+          "$$hashKey": "object:36536",
           "checked": true,
           "visualize": "true"
         },
@@ -17595,7 +17369,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38015",
+          "$$hashKey": "object:36537",
           "checked": true,
           "visualize": "true"
         },
@@ -17606,7 +17380,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38016",
+          "$$hashKey": "object:36538",
           "checked": true,
           "visualize": "true"
         },
@@ -17617,7 +17391,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38017",
+          "$$hashKey": "object:36539",
           "checked": true,
           "visualize": "true"
         },
@@ -17628,7 +17402,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38018",
+          "$$hashKey": "object:36540",
           "checked": true,
           "visualize": "true"
         },
@@ -17639,7 +17413,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38019",
+          "$$hashKey": "object:36541",
           "checked": true,
           "visualize": "true"
         },
@@ -17650,7 +17424,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38020",
+          "$$hashKey": "object:36542",
           "checked": true,
           "visualize": "true"
         },
@@ -17661,7 +17435,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38021",
+          "$$hashKey": "object:36543",
           "checked": true,
           "visualize": "true"
         },
@@ -17672,7 +17446,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38022",
+          "$$hashKey": "object:36544",
           "checked": true,
           "visualize": "true"
         },
@@ -17683,7 +17457,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38023",
+          "$$hashKey": "object:36545",
           "checked": true,
           "visualize": "true"
         },
@@ -17694,7 +17468,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38024",
+          "$$hashKey": "object:36546",
           "checked": true,
           "visualize": "true"
         },
@@ -17705,7 +17479,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38025",
+          "$$hashKey": "object:36547",
           "checked": true,
           "visualize": "true"
         },
@@ -17716,7 +17490,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38026",
+          "$$hashKey": "object:36548",
           "checked": true,
           "visualize": "true"
         },
@@ -17727,7 +17501,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38027",
+          "$$hashKey": "object:36549",
           "checked": true,
           "visualize": "true"
         },
@@ -17738,7 +17512,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38028",
+          "$$hashKey": "object:36550",
           "checked": true,
           "visualize": "true"
         },
@@ -17749,7 +17523,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38029",
+          "$$hashKey": "object:36551",
           "checked": true,
           "visualize": "true"
         },
@@ -17760,7 +17534,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38030",
+          "$$hashKey": "object:36552",
           "checked": true,
           "visualize": "true"
         },
@@ -17771,7 +17545,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38031",
+          "$$hashKey": "object:36553",
           "checked": true,
           "visualize": "true"
         },
@@ -17782,7 +17556,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38032",
+          "$$hashKey": "object:36554",
           "checked": true,
           "visualize": "true"
         },
@@ -17793,7 +17567,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38033",
+          "$$hashKey": "object:36555",
           "checked": true,
           "visualize": "true"
         },
@@ -17804,7 +17578,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38034",
+          "$$hashKey": "object:36556",
           "checked": true,
           "visualize": "true"
         },
@@ -17815,7 +17589,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38035",
+          "$$hashKey": "object:36557",
           "checked": true,
           "visualize": "true"
         },
@@ -17826,7 +17600,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38036",
+          "$$hashKey": "object:36558",
           "checked": true,
           "visualize": "true"
         },
@@ -17837,7 +17611,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38037",
+          "$$hashKey": "object:36559",
           "checked": true,
           "visualize": "true"
         },
@@ -17848,7 +17622,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38038",
+          "$$hashKey": "object:36560",
           "checked": true,
           "visualize": "true"
         },
@@ -17859,7 +17633,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38039",
+          "$$hashKey": "object:36561",
           "checked": true,
           "visualize": "true"
         },
@@ -17870,7 +17644,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38040",
+          "$$hashKey": "object:36562",
           "checked": true,
           "visualize": "true"
         },
@@ -17881,7 +17655,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38041",
+          "$$hashKey": "object:36563",
           "checked": true,
           "visualize": "true"
         },
@@ -17892,7 +17666,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38042",
+          "$$hashKey": "object:36564",
           "checked": true,
           "visualize": "true"
         },
@@ -17903,7 +17677,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38043",
+          "$$hashKey": "object:36565",
           "checked": true,
           "visualize": "true"
         },
@@ -17914,7 +17688,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38044",
+          "$$hashKey": "object:36566",
           "checked": true,
           "visualize": "true"
         },
@@ -17925,7 +17699,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38045",
+          "$$hashKey": "object:36567",
           "checked": true,
           "visualize": "true"
         },
@@ -17936,7 +17710,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38046",
+          "$$hashKey": "object:36568",
           "checked": true,
           "visualize": "true"
         },
@@ -17947,7 +17721,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38047",
+          "$$hashKey": "object:36569",
           "checked": true,
           "visualize": "true"
         },
@@ -17958,7 +17732,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38048",
+          "$$hashKey": "object:36570",
           "checked": true,
           "visualize": "true"
         },
@@ -17969,7 +17743,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38049",
+          "$$hashKey": "object:36571",
           "checked": true,
           "visualize": "true"
         },
@@ -17980,7 +17754,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38050",
+          "$$hashKey": "object:36572",
           "checked": true,
           "visualize": "true"
         },
@@ -17991,7 +17765,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38051",
+          "$$hashKey": "object:36573",
           "checked": true,
           "visualize": "true"
         },
@@ -18002,7 +17776,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38052",
+          "$$hashKey": "object:36574",
           "checked": true,
           "visualize": "true"
         },
@@ -18013,7 +17787,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38053",
+          "$$hashKey": "object:36575",
           "checked": true,
           "visualize": "true"
         },
@@ -18024,7 +17798,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38054",
+          "$$hashKey": "object:36576",
           "checked": true,
           "visualize": "true"
         },
@@ -18035,7 +17809,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38055",
+          "$$hashKey": "object:36577",
           "checked": true,
           "visualize": "true"
         },
@@ -18046,7 +17820,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38056",
+          "$$hashKey": "object:36578",
           "checked": true,
           "visualize": "true"
         },
@@ -18057,7 +17831,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38057",
+          "$$hashKey": "object:36579",
           "checked": true,
           "visualize": "true"
         },
@@ -18068,7 +17842,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38058",
+          "$$hashKey": "object:36580",
           "checked": true,
           "visualize": "true"
         },
@@ -18079,7 +17853,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38059",
+          "$$hashKey": "object:36581",
           "checked": true,
           "visualize": "true"
         },
@@ -18090,7 +17864,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38060",
+          "$$hashKey": "object:36582",
           "checked": true,
           "visualize": "true"
         },
@@ -18101,7 +17875,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38061",
+          "$$hashKey": "object:36583",
           "checked": true,
           "visualize": "true"
         },
@@ -18112,7 +17886,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:38062",
+          "$$hashKey": "object:36584",
           "checked": true,
           "visualize": "true"
         }
@@ -18137,15 +17911,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "12/10/2019",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.2588349433633539,
+      "instanceId": 0.38561400244525723,
       "skip": false,
-      "$$hashKey": "object:33647",
+      "$$hashKey": "object:33271",
       "outputMeasure": true,
       "userDefinedOutputs": [],
       "analysisOutputs": [
@@ -18156,7 +17930,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37956",
+          "$$hashKey": "object:36476",
           "checked": true,
           "visualize": "true"
         },
@@ -18167,7 +17941,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37957",
+          "$$hashKey": "object:36477",
           "checked": true,
           "visualize": "true"
         },
@@ -18178,7 +17952,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37958",
+          "$$hashKey": "object:36478",
           "checked": true,
           "visualize": "true"
         },
@@ -18189,7 +17963,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37959",
+          "$$hashKey": "object:36479",
           "checked": true,
           "visualize": "true"
         },
@@ -18200,7 +17974,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37960",
+          "$$hashKey": "object:36480",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "total_site_wood_mbtu",
+          "display_name": "total_site_wood_mbtu",
+          "short_name": "total_site_wood_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36481",
           "checked": true,
           "visualize": "true"
         },
@@ -18211,7 +17996,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37961",
+          "$$hashKey": "object:36482",
           "checked": true,
           "visualize": "true"
         },
@@ -18222,7 +18007,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37962",
+          "$$hashKey": "object:36483",
           "checked": true,
           "visualize": "true"
         },
@@ -18233,7 +18018,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37963",
+          "$$hashKey": "object:36484",
           "checked": true,
           "visualize": "true"
         },
@@ -18244,7 +18029,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37964",
+          "$$hashKey": "object:36485",
           "checked": true,
           "visualize": "true"
         },
@@ -18255,7 +18040,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37965",
+          "$$hashKey": "object:36486",
           "checked": true,
           "visualize": "true"
         },
@@ -18266,7 +18051,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37966",
+          "$$hashKey": "object:36487",
           "checked": true,
           "visualize": "true"
         },
@@ -18277,7 +18062,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37967",
+          "$$hashKey": "object:36488",
           "checked": true,
           "visualize": "true"
         },
@@ -18288,7 +18073,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37968",
+          "$$hashKey": "object:36489",
           "checked": true,
           "visualize": "true"
         },
@@ -18299,7 +18084,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37969",
+          "$$hashKey": "object:36490",
           "checked": true,
           "visualize": "true"
         },
@@ -18310,7 +18095,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37970",
+          "$$hashKey": "object:36491",
           "checked": true,
           "visualize": "true"
         },
@@ -18321,7 +18106,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37971",
+          "$$hashKey": "object:36492",
           "checked": true,
           "visualize": "true"
         },
@@ -18332,7 +18117,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37972",
+          "$$hashKey": "object:36493",
           "checked": true,
           "visualize": "true"
         },
@@ -18343,7 +18128,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37973",
+          "$$hashKey": "object:36494",
           "checked": true,
           "visualize": "true"
         },
@@ -18354,7 +18139,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37974",
+          "$$hashKey": "object:36495",
           "checked": true,
           "visualize": "true"
         },
@@ -18365,7 +18150,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37975",
+          "$$hashKey": "object:36496",
           "checked": true,
           "visualize": "true"
         },
@@ -18376,7 +18161,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37976",
+          "$$hashKey": "object:36497",
           "checked": true,
           "visualize": "true"
         },
@@ -18387,7 +18172,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37977",
+          "$$hashKey": "object:36498",
           "checked": true,
           "visualize": "true"
         },
@@ -18398,7 +18183,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37978",
+          "$$hashKey": "object:36499",
           "checked": true,
           "visualize": "true"
         },
@@ -18409,7 +18194,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37979",
+          "$$hashKey": "object:36500",
           "checked": true,
           "visualize": "true"
         },
@@ -18420,7 +18205,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37980",
+          "$$hashKey": "object:36501",
           "checked": true,
           "visualize": "true"
         },
@@ -18431,7 +18216,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37981",
+          "$$hashKey": "object:36502",
           "checked": true,
           "visualize": "true"
         },
@@ -18442,7 +18227,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37982",
+          "$$hashKey": "object:36503",
           "checked": true,
           "visualize": "true"
         },
@@ -18453,7 +18238,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37983",
+          "$$hashKey": "object:36504",
           "checked": true,
           "visualize": "true"
         },
@@ -18464,7 +18249,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37984",
+          "$$hashKey": "object:36505",
           "checked": true,
           "visualize": "true"
         },
@@ -18475,7 +18260,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37985",
+          "$$hashKey": "object:36506",
           "checked": true,
           "visualize": "true"
         },
@@ -18486,7 +18271,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37986",
+          "$$hashKey": "object:36507",
           "checked": true,
           "visualize": "true"
         },
@@ -18497,7 +18282,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37987",
+          "$$hashKey": "object:36508",
           "checked": true,
           "visualize": "true"
         },
@@ -18508,7 +18293,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37988",
+          "$$hashKey": "object:36509",
           "checked": true,
           "visualize": "true"
         },
@@ -18519,7 +18304,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37989",
+          "$$hashKey": "object:36510",
           "checked": true,
           "visualize": "true"
         },
@@ -18530,7 +18315,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37990",
+          "$$hashKey": "object:36511",
           "checked": true,
           "visualize": "true"
         },
@@ -18541,7 +18326,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37991",
+          "$$hashKey": "object:36512",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "wood_heating_mbtu",
+          "display_name": "wood_heating_mbtu",
+          "short_name": "wood_heating_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36513",
           "checked": true,
           "visualize": "true"
         },
@@ -18552,7 +18348,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37992",
+          "$$hashKey": "object:36514",
           "checked": true,
           "visualize": "true"
         },
@@ -18563,7 +18359,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37993",
+          "$$hashKey": "object:36515",
           "checked": true,
           "visualize": "true"
         },
@@ -18574,7 +18370,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37994",
+          "$$hashKey": "object:36516",
           "checked": true,
           "visualize": "true"
         },
@@ -18585,7 +18381,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37995",
+          "$$hashKey": "object:36517",
           "checked": true,
           "visualize": "true"
         },
@@ -18596,7 +18392,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37996",
+          "$$hashKey": "object:36518",
           "checked": true,
           "visualize": "true"
         },
@@ -18607,7 +18403,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37997",
+          "$$hashKey": "object:36519",
           "checked": true,
           "visualize": "true"
         },
@@ -18618,7 +18414,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37998",
+          "$$hashKey": "object:36520",
           "checked": true,
           "visualize": "true"
         },
@@ -18629,7 +18425,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37999",
+          "$$hashKey": "object:36521",
           "checked": true,
           "visualize": "true"
         },
@@ -18640,7 +18436,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38000",
+          "$$hashKey": "object:36522",
           "checked": true,
           "visualize": "true"
         },
@@ -18651,7 +18447,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38001",
+          "$$hashKey": "object:36523",
           "checked": true,
           "visualize": "true"
         },
@@ -18662,7 +18458,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38002",
+          "$$hashKey": "object:36524",
           "checked": true,
           "visualize": "true"
         },
@@ -18673,7 +18469,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38003",
+          "$$hashKey": "object:36525",
           "checked": true,
           "visualize": "true"
         },
@@ -18684,7 +18480,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38004",
+          "$$hashKey": "object:36526",
           "checked": true,
           "visualize": "true"
         },
@@ -18695,7 +18491,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38005",
+          "$$hashKey": "object:36527",
           "checked": true,
           "visualize": "true"
         },
@@ -18706,7 +18502,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38006",
+          "$$hashKey": "object:36528",
           "checked": true,
           "visualize": "true"
         },
@@ -18717,7 +18513,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38007",
+          "$$hashKey": "object:36529",
           "checked": true,
           "visualize": "true"
         },
@@ -18728,7 +18524,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38008",
+          "$$hashKey": "object:36530",
           "checked": true,
           "visualize": "true"
         },
@@ -18739,7 +18535,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38009",
+          "$$hashKey": "object:36531",
           "checked": true,
           "visualize": "true"
         },
@@ -18750,7 +18546,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38010",
+          "$$hashKey": "object:36532",
           "checked": true,
           "visualize": "true"
         },
@@ -18761,7 +18557,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38011",
+          "$$hashKey": "object:36533",
           "checked": true,
           "visualize": "true"
         },
@@ -18772,7 +18568,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38012",
+          "$$hashKey": "object:36534",
           "checked": true,
           "visualize": "true"
         },
@@ -18783,7 +18579,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38013",
+          "$$hashKey": "object:36535",
           "checked": true,
           "visualize": "true"
         },
@@ -18794,7 +18590,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38014",
+          "$$hashKey": "object:36536",
           "checked": true,
           "visualize": "true"
         },
@@ -18805,7 +18601,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38015",
+          "$$hashKey": "object:36537",
           "checked": true,
           "visualize": "true"
         },
@@ -18816,7 +18612,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38016",
+          "$$hashKey": "object:36538",
           "checked": true,
           "visualize": "true"
         },
@@ -18827,7 +18623,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38017",
+          "$$hashKey": "object:36539",
           "checked": true,
           "visualize": "true"
         },
@@ -18838,7 +18634,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38018",
+          "$$hashKey": "object:36540",
           "checked": true,
           "visualize": "true"
         },
@@ -18849,7 +18645,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38019",
+          "$$hashKey": "object:36541",
           "checked": true,
           "visualize": "true"
         },
@@ -18860,7 +18656,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38020",
+          "$$hashKey": "object:36542",
           "checked": true,
           "visualize": "true"
         },
@@ -18871,7 +18667,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38021",
+          "$$hashKey": "object:36543",
           "checked": true,
           "visualize": "true"
         },
@@ -18882,7 +18678,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38022",
+          "$$hashKey": "object:36544",
           "checked": true,
           "visualize": "true"
         },
@@ -18893,7 +18689,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38023",
+          "$$hashKey": "object:36545",
           "checked": true,
           "visualize": "true"
         },
@@ -18904,7 +18700,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38024",
+          "$$hashKey": "object:36546",
           "checked": true,
           "visualize": "true"
         },
@@ -18915,7 +18711,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38025",
+          "$$hashKey": "object:36547",
           "checked": true,
           "visualize": "true"
         },
@@ -18926,7 +18722,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38026",
+          "$$hashKey": "object:36548",
           "checked": true,
           "visualize": "true"
         },
@@ -18937,7 +18733,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38027",
+          "$$hashKey": "object:36549",
           "checked": true,
           "visualize": "true"
         },
@@ -18948,7 +18744,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38028",
+          "$$hashKey": "object:36550",
           "checked": true,
           "visualize": "true"
         },
@@ -18959,7 +18755,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38029",
+          "$$hashKey": "object:36551",
           "checked": true,
           "visualize": "true"
         },
@@ -18970,7 +18766,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38030",
+          "$$hashKey": "object:36552",
           "checked": true,
           "visualize": "true"
         },
@@ -18981,7 +18777,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38031",
+          "$$hashKey": "object:36553",
           "checked": true,
           "visualize": "true"
         },
@@ -18992,7 +18788,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38032",
+          "$$hashKey": "object:36554",
           "checked": true,
           "visualize": "true"
         },
@@ -19003,7 +18799,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38033",
+          "$$hashKey": "object:36555",
           "checked": true,
           "visualize": "true"
         },
@@ -19014,7 +18810,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38034",
+          "$$hashKey": "object:36556",
           "checked": true,
           "visualize": "true"
         },
@@ -19025,7 +18821,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38035",
+          "$$hashKey": "object:36557",
           "checked": true,
           "visualize": "true"
         },
@@ -19036,7 +18832,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38036",
+          "$$hashKey": "object:36558",
           "checked": true,
           "visualize": "true"
         },
@@ -19047,7 +18843,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38037",
+          "$$hashKey": "object:36559",
           "checked": true,
           "visualize": "true"
         },
@@ -19058,7 +18854,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38038",
+          "$$hashKey": "object:36560",
           "checked": true,
           "visualize": "true"
         },
@@ -19069,7 +18865,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38039",
+          "$$hashKey": "object:36561",
           "checked": true,
           "visualize": "true"
         },
@@ -19080,7 +18876,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38040",
+          "$$hashKey": "object:36562",
           "checked": true,
           "visualize": "true"
         },
@@ -19091,7 +18887,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38041",
+          "$$hashKey": "object:36563",
           "checked": true,
           "visualize": "true"
         },
@@ -19102,7 +18898,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38042",
+          "$$hashKey": "object:36564",
           "checked": true,
           "visualize": "true"
         },
@@ -19113,7 +18909,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38043",
+          "$$hashKey": "object:36565",
           "checked": true,
           "visualize": "true"
         },
@@ -19124,7 +18920,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38044",
+          "$$hashKey": "object:36566",
           "checked": true,
           "visualize": "true"
         },
@@ -19135,7 +18931,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38045",
+          "$$hashKey": "object:36567",
           "checked": true,
           "visualize": "true"
         },
@@ -19146,7 +18942,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38046",
+          "$$hashKey": "object:36568",
           "checked": true,
           "visualize": "true"
         },
@@ -19157,7 +18953,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38047",
+          "$$hashKey": "object:36569",
           "checked": true,
           "visualize": "true"
         },
@@ -19168,7 +18964,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38048",
+          "$$hashKey": "object:36570",
           "checked": true,
           "visualize": "true"
         },
@@ -19179,7 +18975,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38049",
+          "$$hashKey": "object:36571",
           "checked": true,
           "visualize": "true"
         },
@@ -19190,7 +18986,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38050",
+          "$$hashKey": "object:36572",
           "checked": true,
           "visualize": "true"
         },
@@ -19201,7 +18997,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38051",
+          "$$hashKey": "object:36573",
           "checked": true,
           "visualize": "true"
         },
@@ -19212,7 +19008,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38052",
+          "$$hashKey": "object:36574",
           "checked": true,
           "visualize": "true"
         },
@@ -19223,7 +19019,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38053",
+          "$$hashKey": "object:36575",
           "checked": true,
           "visualize": "true"
         },
@@ -19234,7 +19030,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38054",
+          "$$hashKey": "object:36576",
           "checked": true,
           "visualize": "true"
         },
@@ -19245,7 +19041,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38055",
+          "$$hashKey": "object:36577",
           "checked": true,
           "visualize": "true"
         },
@@ -19256,7 +19052,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38056",
+          "$$hashKey": "object:36578",
           "checked": true,
           "visualize": "true"
         },
@@ -19267,7 +19063,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38057",
+          "$$hashKey": "object:36579",
           "checked": true,
           "visualize": "true"
         },
@@ -19278,7 +19074,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38058",
+          "$$hashKey": "object:36580",
           "checked": true,
           "visualize": "true"
         },
@@ -19289,7 +19085,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38059",
+          "$$hashKey": "object:36581",
           "checked": true,
           "visualize": "true"
         },
@@ -19300,7 +19096,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38060",
+          "$$hashKey": "object:36582",
           "checked": true,
           "visualize": "true"
         },
@@ -19311,7 +19107,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38061",
+          "$$hashKey": "object:36583",
           "checked": true,
           "visualize": "true"
         },
@@ -19322,7 +19118,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:38062",
+          "$$hashKey": "object:36584",
           "checked": true,
           "visualize": "true"
         }
@@ -19331,12 +19127,12 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\TimeseriesCSVExport",
       "name": "timeseries_csv_export",
-      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\TimeseriesCSVExport",
+      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/TimeseriesCSVExport",
       "uid": "2a3442c1-944d-4e91-9e11-11e0cf368c64",
       "uuid": "{2a3442c1-944d-4e91-9e11-11e0cf368c64}",
-      "version_id": "64696f29-6d80-4418-b20d-61f5bdff5495",
-      "version_uuid": "{64696f29-6d80-4418-b20d-61f5bdff5495}",
-      "version_modified": "20191210T220251Z",
+      "version_id": "cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03",
+      "version_uuid": "{cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03}",
+      "version_modified": "20200123T180929Z",
       "xml_checksum": "15BF4E57",
       "display_name": "Timeseries CSV Export",
       "class_name": "TimeseriesCSVExport",
@@ -19391,7 +19187,7 @@
             "stdDev": "Hourly",
             "default_value": "Hourly"
           },
-          "$$hashKey": "object:14635"
+          "$$hashKey": "object:33360"
         },
         {
           "name": "include_enduse_subcategories",
@@ -19415,7 +19211,7 @@
             "stdDev": false,
             "default_value": false
           },
-          "$$hashKey": "object:14636"
+          "$$hashKey": "object:33361"
         },
         {
           "name": "output_variables",
@@ -19438,7 +19234,7 @@
             "stdDev": "",
             "default_value": ""
           },
-          "$$hashKey": "object:14637"
+          "$$hashKey": "object:33362"
         }
       ],
       "edit": "",
@@ -19448,18 +19244,16 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "12/10/2019",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.0874684839171811,
+      "instanceId": 0.6214318987432228,
       "skip": false,
-      "$$hashKey": "object:14592",
-      "outputMeasure": false,
-      "userDefinedOutputs": [],
-      "analysisOutputs": []
+      "$$hashKey": "object:33272",
+      "outputMeasure": false
     },
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_singlefamilydetached\\measures\\ServerDirectoryCleanup",
@@ -19503,7 +19297,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.7711727522582181,
+      "instanceId": 0.8809064205845409,
       "skip": false,
       "$$hashKey": "object:663249",
       "outputMeasure": false

--- a/project_testing/measures/BuildingCharacteristicsReport/measure.xml
+++ b/project_testing/measures/BuildingCharacteristicsReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>building_characteristics_report</name>
   <uid>90eecbe2-d8e2-47db-9079-5d9029fb3e67</uid>
-  <version_id>da2102f5-b790-465d-9394-f012fe4ddad3</version_id>
-  <version_modified>20200118T172411Z</version_modified>
+  <version_id>1f44b04d-9e14-4f5d-8c10-7240262b845c</version_id>
+  <version_modified>20200123T175727Z</version_modified>
   <xml_checksum>2EA103AF</xml_checksum>
   <class_name>BuildingCharacteristicsReport</class_name>
   <display_name>Building Characteristics Report</display_name>
@@ -906,7 +906,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>CE447A1E</checksum>
+      <checksum>F5F682BD</checksum>
     </file>
   </files>
 </measure>

--- a/project_testing/measures/SimulationOutputReport/measure.rb
+++ b/project_testing/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation outputs of interest."
+    return "Reports simulation ou tputs of interest."
   end
 
   def num_options
@@ -66,6 +66,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "total_site_natural_gas_therm",
       "total_site_fuel_oil_mbtu",
       "total_site_propane_mbtu",
+      "total_site_wood_mbtu",
       "net_site_energy_mbtu", # Incorporates PV
       "net_site_electricity_kwh", # Incorporates PV
       "electricity_heating_kwh",
@@ -97,6 +98,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
       "propane_central_system_heating_mbtu",
       "propane_interior_equipment_mbtu",
       "propane_water_systems_mbtu",
+      "wood_heating_mbtu",
       "hours_heating_setpoint_not_met",
       "hours_cooling_setpoint_not_met",
       "hvac_cooling_capacity_w",
@@ -191,6 +193,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
     hours_setpoint_not_met = output_meters.hours_setpoint_not_met(sqlFile)
 
     # ELECTRICITY
@@ -290,12 +293,18 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
     report_sim_output(runner, "propane_interior_equipment_mbtu", propane.interior_equipment[0], "GJ", other_fuel_site_units)
     report_sim_output(runner, "propane_water_systems_mbtu", propane.water_systems[0], "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_sim_output(runner, "total_site_wood_mbtu", wood.total_end_uses[0], "GJ", other_fuel_site_units)
+    report_sim_output(runner, "wood_heating_mbtu", wood.heating[0], "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses[0] +
                       natural_gas.total_end_uses[0] +
                       fuel_oil.total_end_uses[0] +
-                      propane.total_end_uses[0]
+                      propane.total_end_uses[0] +
+                      wood.total_end_uses[0]
 
     if units.length == total_units_represented
       err = totalSiteEnergy - sqlFile.totalSiteEnergy.get

--- a/project_testing/measures/SimulationOutputReport/measure.rb
+++ b/project_testing/measures/SimulationOutputReport/measure.rb
@@ -20,7 +20,7 @@ class SimulationOutputReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def description
-    return "Reports simulation ou tputs of interest."
+    return "Reports simulation outputs of interest."
   end
 
   def num_options

--- a/project_testing/measures/SimulationOutputReport/measure.xml
+++ b/project_testing/measures/SimulationOutputReport/measure.xml
@@ -2,12 +2,12 @@
   <schema_version>3.0</schema_version>
   <name>simulation_output_report</name>
   <uid>fc337100-8634-404e-8966-01243d292a79</uid>
-  <version_id>452c3c75-928b-4c49-93f5-dc319088b009</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>2992ab1b-5569-465c-a32b-c622a453a3cb</version_id>
+  <version_modified>20200123T175728Z</version_modified>
   <xml_checksum>2C8A3EEF</xml_checksum>
   <class_name>SimulationOutputReport</class_name>
   <display_name>Simulation Output Report</display_name>
-  <description>Reports simulation outputs of interest.</description>
+  <description>Reports simulation ou tputs of interest.</description>
   <modeler_description>Change me</modeler_description>
   <arguments/>
   <outputs>
@@ -43,6 +43,13 @@
       <name>total_site_propane_mbtu</name>
       <display_name>total_site_propane_mbtu</display_name>
       <short_name>total_site_propane_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>total_site_wood_mbtu</name>
+      <display_name>total_site_wood_mbtu</display_name>
+      <short_name>total_site_wood_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -260,6 +267,13 @@
       <name>propane_water_systems_mbtu</name>
       <display_name>propane_water_systems_mbtu</display_name>
       <short_name>propane_water_systems_mbtu</short_name>
+      <type>Double</type>
+      <model_dependent>false</model_dependent>
+    </output>
+    <output>
+      <name>wood_heating_mbtu</name>
+      <display_name>wood_heating_mbtu</display_name>
+      <short_name>wood_heating_mbtu</short_name>
       <type>Double</type>
       <model_dependent>false</model_dependent>
     </output>
@@ -793,7 +807,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>0EBF3BC0</checksum>
+      <checksum>11288408</checksum>
     </file>
   </files>
 </measure>

--- a/project_testing/measures/TimeseriesCSVExport/measure.rb
+++ b/project_testing/measures/TimeseriesCSVExport/measure.rb
@@ -192,6 +192,7 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     natural_gas = output_meters.natural_gas(sqlFile, ann_env_pd)
     fuel_oil = output_meters.fuel_oil(sqlFile, ann_env_pd)
     propane = output_meters.propane(sqlFile, ann_env_pd)
+    wood = output_meters.wood(sqlFile, ann_env_pd)
 
     # ELECTRICITY
 
@@ -239,12 +240,18 @@ class TimeseriesCSVExport < OpenStudio::Measure::ReportingMeasure
     report_ts_output(runner, timeseries, "propane_interior_equipment_mbtu", propane.interior_equipment, "GJ", other_fuel_site_units)
     report_ts_output(runner, timeseries, "propane_water_systems_mbtu", propane.water_systems, "GJ", other_fuel_site_units)
 
+    # WOOD
+
+    report_ts_output(runner, timeseries, "total_site_wood_mbtu", wood.total_end_uses, "GJ", other_fuel_site_units)
+    report_ts_output(runner, timeseries, "wood_heating_mbtu", wood.heating, "GJ", other_fuel_site_units)
+
     # TOTAL
 
     totalSiteEnergy = electricity.total_end_uses +
                       natural_gas.total_end_uses +
                       fuel_oil.total_end_uses +
-                      propane.total_end_uses
+                      propane.total_end_uses +
+                      wood.total_end_uses
 
     report_ts_output(runner, timeseries, "total_site_energy_mbtu", totalSiteEnergy, "GJ", total_site_units)
     report_ts_output(runner, timeseries, "net_site_energy_mbtu", totalSiteEnergy - electricity.photovoltaics, "GJ", total_site_units)

--- a/project_testing/measures/TimeseriesCSVExport/measure.xml
+++ b/project_testing/measures/TimeseriesCSVExport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>timeseries_csv_export</name>
   <uid>2a3442c1-944d-4e91-9e11-11e0cf368c64</uid>
-  <version_id>64696f29-6d80-4418-b20d-61f5bdff5495</version_id>
-  <version_modified>20191210T220251Z</version_modified>
+  <version_id>cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03</version_id>
+  <version_modified>20200123T180929Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>TimeseriesCSVExport</class_name>
   <display_name>Timeseries CSV Export</display_name>
@@ -79,6 +79,12 @@
   </attributes>
   <files>
     <file>
+      <filename>timeseries_csv_export_test.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3A9D58E2</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>2.0.5</identifier>
@@ -87,13 +93,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>6C92E878</checksum>
-    </file>
-    <file>
-      <filename>timeseries_csv_export_test.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>test</usage_type>
-      <checksum>F8C982FF</checksum>
+      <checksum>731388DC</checksum>
     </file>
   </files>
 </measure>

--- a/project_testing/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_testing/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -13,7 +13,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Timestep"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Zone Mean Air Temperature, Site Outdoor Air Drybulb Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 34 + 28 + 5 }
+    expected_values = { "EnduseTimeseriesLength" => 8784 * 6, "EnduseTimeseriesWidth" => 36 + 28 + 5 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2012.epw", num_output_requests)
   end
 

--- a/project_testing/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
+++ b/project_testing/measures/TimeseriesCSVExport/tests/timeseries_csv_export_test.rb
@@ -22,7 +22,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 24, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -32,7 +32,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 2 * 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -53,7 +53,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Zone People Occupant Count"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_values, __method__, "0465925_US_CO_Boulder_8013_0-20000-0-72469_40.13_-105.22_NSRDB_2.0.1_AMY_2014.epw", num_output_requests)
   end
 
@@ -62,7 +62,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     measure = TimeseriesCSVExport.new
     args_hash = {}
     args_hash["output_variables"] = "Site Wind Direction"
-    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 36 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 8760, "EnduseTimeseriesWidth" => 38 + 1 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -73,7 +73,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["reporting_frequency"] = "Daily"
     args_hash["output_variables"] = "Electric Equipment Electric Power, Zone Air Heat Balance Internal Convective Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 9 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 9 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -94,7 +94,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash = {}
     args_hash["reporting_frequency"] = "RunPeriod"
     args_hash["output_variables"] = "Surface Outside Normal Azimuth Angle, Surface Window Heat Gain Rate"
-    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 36 + 71 }
+    expected_values = { "EnduseTimeseriesLength" => 1, "EnduseTimeseriesWidth" => 38 + 71 }
     _test_measure("SFD_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 
@@ -106,7 +106,7 @@ class TimeseriesCSVExportTest < MiniTest::Test
     args_hash["reporting_frequency"] = "Daily"
     args_hash["include_enduse_subcategories"] = "true"
     args_hash["output_variables"] = "Cooling Coil Runtime Fraction, Unitary System Ancillary Electric Power, System Node Temperature"
-    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 34 + 28 + 1 }
+    expected_values = { "EnduseTimeseriesLength" => 365, "EnduseTimeseriesWidth" => 36 + 28 + 1 }
     _test_measure("MF_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_values, __method__, "USA_CO_Denver.Intl.AP.725650_TMY3.epw", num_output_requests)
   end
 

--- a/project_testing/pat.json
+++ b/project_testing/pat.json
@@ -312,7 +312,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 0,
       "options": [],
-      "instanceId": 0.9850889594145404,
+      "instanceId": 0.4507727507900112,
       "skip": false,
       "$$hashKey": "object:12202",
       "outputMeasure": false
@@ -320,7 +320,7 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\BuildExistingModel",
       "name": "build_existing_model",
-      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildExistingModel",
+      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\BuildExistingModel",
       "uid": "dedf59bb-3b88-4f16-8755-2c1ff5519cbf",
       "uuid": "{dedf59bb-3b88-4f16-8755-2c1ff5519cbf}",
       "version_id": "ddb1178a-cb38-492a-84d7-534fd5d25142",
@@ -494,7 +494,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 1,
       "options": [],
-      "instanceId": 0.45401475737445485,
+      "instanceId": 0.8661057555103882,
       "skip": false,
       "$$hashKey": "object:32355",
       "showWarningText": false,
@@ -7316,7 +7316,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 2,
       "options": [],
-      "instanceId": 0.3257500420366739,
+      "instanceId": 0.07690980262521108,
       "skip": false,
       "$$hashKey": "object:38492",
       "showWarningText": false,
@@ -14138,21 +14138,21 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 3,
       "options": [],
-      "instanceId": 0.9875781983212477,
+      "instanceId": 0.9603240184420367,
       "skip": false,
       "$$hashKey": "object:44414",
       "showWarningText": false,
       "outputMeasure": false
     },
     {
-      "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\BuildingCharacteristicsReport",
+      "measure_dir": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "name": "building_characteristics_report",
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/BuildingCharacteristicsReport",
       "uid": "90eecbe2-d8e2-47db-9079-5d9029fb3e67",
       "uuid": "{90eecbe2-d8e2-47db-9079-5d9029fb3e67}",
-      "version_id": "da2102f5-b790-465d-9394-f012fe4ddad3",
-      "version_uuid": "{da2102f5-b790-465d-9394-f012fe4ddad3}",
-      "version_modified": "20200118T172411Z",
+      "version_id": "1f44b04d-9e14-4f5d-8c10-7240262b845c",
+      "version_uuid": "{1f44b04d-9e14-4f5d-8c10-7240262b845c}",
+      "version_modified": "20200123T175727Z",
       "xml_checksum": "2EA103AF",
       "display_name": "Building Characteristics Report",
       "class_name": "BuildingCharacteristicsReport",
@@ -14167,9 +14167,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34107",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_heating_region",
@@ -14178,9 +14176,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34108",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_cooling_region",
@@ -14189,9 +14185,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34109",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location",
@@ -14200,9 +14194,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34110",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_weather_filename",
@@ -14211,9 +14203,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34111",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_weather_year",
@@ -14222,9 +14212,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34112",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "vintage",
@@ -14233,9 +14221,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34113",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "vintage_acs",
@@ -14244,9 +14230,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34114",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_fuel",
@@ -14255,9 +14239,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34115",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "usage_level",
@@ -14266,9 +14248,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34116",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_attic_type",
@@ -14277,9 +14257,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34117",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_type_recs",
@@ -14288,9 +14266,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34118",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_type_acs",
@@ -14299,9 +14275,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34119",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_number_units",
@@ -14310,9 +14284,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34120",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_mf",
@@ -14321,9 +14293,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34121",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_sfa",
@@ -14332,9 +14302,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34122",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_building_number_units_hl",
@@ -14343,9 +14311,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34123",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_foundation_type",
@@ -14354,9 +14320,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34124",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_heated_basement",
@@ -14365,9 +14329,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34125",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_wall_type",
@@ -14376,9 +14338,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34126",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_stories",
@@ -14387,9 +14347,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34127",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_garage",
@@ -14398,9 +14356,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34128",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_house_size",
@@ -14409,9 +14365,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34129",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "bedrooms",
@@ -14420,9 +14374,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34130",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "corridor",
@@ -14431,9 +14383,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34131",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_number_units_acs_bins",
@@ -14442,9 +14392,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34132",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_unit_stories_sf",
@@ -14453,9 +14401,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34133",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_unit_stories_mf",
@@ -14464,9 +14410,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34134",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "occupants",
@@ -14475,9 +14419,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34135",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "orientation",
@@ -14486,9 +14428,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34136",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "eaves",
@@ -14497,9 +14437,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34137",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "door_area",
@@ -14508,9 +14446,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34138",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "window_areas",
@@ -14519,9 +14455,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34139",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "overhangs",
@@ -14530,9 +14464,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34140",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "neighbors",
@@ -14541,9 +14473,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34141",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_unfinished_attic",
@@ -14552,9 +14482,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34142",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_finished_roof",
@@ -14563,9 +14491,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34143",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "radiant_barrier_unfinished_attic",
@@ -14574,9 +14500,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34144",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "roof_material",
@@ -14585,9 +14509,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34145",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_slab",
@@ -14596,9 +14518,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34146",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_crawlspace",
@@ -14607,9 +14527,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34147",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_unfinished_basement",
@@ -14618,9 +14536,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34148",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_finished_basement",
@@ -14629,9 +14545,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34149",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_pier_beam",
@@ -14640,9 +14554,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34150",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_interzonal_floor",
@@ -14651,9 +14563,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34151",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "insulation_wall",
@@ -14662,9 +14572,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34152",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "interior_shading",
@@ -14673,9 +14581,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34153",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "windows",
@@ -14684,9 +14590,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34154",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "doors",
@@ -14695,9 +14599,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34155",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "water_heater",
@@ -14706,9 +14608,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34156",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hot_water_fixtures",
@@ -14717,9 +14617,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34157",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hot_water_distribution",
@@ -14728,9 +14626,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34158",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "solar_hot_water",
@@ -14739,9 +14635,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34159",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_is_shared",
@@ -14750,9 +14644,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34160",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_electricity",
@@ -14761,9 +14653,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34161",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_natural_gas",
@@ -14772,9 +14662,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34162",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_propane",
@@ -14783,9 +14671,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34163",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_fuel_oil",
@@ -14794,9 +14680,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34164",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_other_fuel",
@@ -14805,9 +14689,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34165",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_shared_none",
@@ -14816,9 +14698,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34166",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_is_heat_pump",
@@ -14827,9 +14707,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34167",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heat_pump",
@@ -14838,9 +14716,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34168",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_electricity",
@@ -14849,9 +14725,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34169",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_natural_gas",
@@ -14860,9 +14734,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34170",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_propane",
@@ -14871,9 +14743,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34171",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_fuel_oil",
@@ -14882,9 +14752,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34172",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_wood",
@@ -14893,9 +14761,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34173",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_other_fuel",
@@ -14904,9 +14770,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34174",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_heating_none",
@@ -14915,9 +14779,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34175",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_cooling",
@@ -14926,9 +14788,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34176",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "hvac_system_cooling_type",
@@ -14937,9 +14797,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34177",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint",
@@ -14948,9 +14806,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34178",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint",
@@ -14959,9 +14815,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34179",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_has_offset",
@@ -14970,9 +14824,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34180",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_has_offset",
@@ -14981,9 +14833,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34181",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_offset_magnitude",
@@ -14992,9 +14842,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34182",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_offset_magnitude",
@@ -15003,9 +14851,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34183",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooling_setpoint_offset_period",
@@ -15014,9 +14860,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34184",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "heating_setpoint_offset_period",
@@ -15025,9 +14869,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34185",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "setpoint_demand_response",
@@ -15036,9 +14878,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34186",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "ceiling_fan",
@@ -15047,9 +14887,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34187",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "dehumidifier",
@@ -15058,9 +14896,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34188",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "refrigerator",
@@ -15069,9 +14905,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34189",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "refrigeration_schedule",
@@ -15080,9 +14914,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34190",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooking_range",
@@ -15091,9 +14923,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34191",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "cooking_range_schedule",
@@ -15102,9 +14932,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34192",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "dishwasher",
@@ -15113,9 +14941,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34193",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "clothes_washer",
@@ -15124,9 +14950,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34194",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "clothes_dryer",
@@ -15135,9 +14959,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34195",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting",
@@ -15146,9 +14968,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34196",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting_interior_use",
@@ -15157,9 +14977,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34197",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "lighting_other_use",
@@ -15168,9 +14986,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34198",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "holiday_lighting",
@@ -15179,9 +14995,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34199",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "plug_loads",
@@ -15190,9 +15004,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34200",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "plug_loads_schedule",
@@ -15201,9 +15013,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34201",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "electric_vehicle",
@@ -15212,9 +15022,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34202",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_extra_refrigerator",
@@ -15223,9 +15031,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34203",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_freezer",
@@ -15234,9 +15040,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34204",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_fireplace",
@@ -15245,9 +15049,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34205",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_grill",
@@ -15256,9 +15058,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34206",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_gas_lighting",
@@ -15267,9 +15067,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34207",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_hot_tub_spa",
@@ -15278,9 +15076,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34208",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool",
@@ -15289,9 +15085,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34209",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_heater",
@@ -15300,9 +15094,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34210",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_pump",
@@ -15311,9 +15103,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34211",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_pool_schedule",
@@ -15322,9 +15112,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34212",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "misc_well_pump",
@@ -15333,9 +15121,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34213",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "ducts",
@@ -15344,9 +15130,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34214",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "infiltration",
@@ -15355,9 +15139,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34215",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "natural_ventilation",
@@ -15366,9 +15148,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34216",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "mechanical_ventilation",
@@ -15377,9 +15157,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34217",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "bathroom_spot_vent_hour",
@@ -15388,9 +15166,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34218",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "range_spot_vent_hour",
@@ -15399,9 +15175,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34219",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "pv",
@@ -15410,9 +15184,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34220",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "days_shifted",
@@ -15421,9 +15193,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34221",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "geometry_perimeter_footprint_ratio",
@@ -15432,9 +15202,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34222",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_city",
@@ -15443,9 +15211,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34223",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_state",
@@ -15454,9 +15220,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34224",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_latitude",
@@ -15465,9 +15229,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34225",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "location_longitude",
@@ -15476,9 +15238,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34226",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "climate_zone_ba",
@@ -15487,9 +15247,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34227",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "climate_zone_iecc",
@@ -15498,9 +15256,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34228",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "units_represented",
@@ -15509,9 +15265,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34229",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         },
         {
           "name": "units_modeled",
@@ -15520,9 +15274,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:34230",
-          "checked": true,
-          "visualize": "true"
+          "checked": true
         }
       ],
       "attributes": [
@@ -15545,13 +15297,13 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "1/18/2020",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 4,
       "options": [],
-      "instanceId": 0.3495874786048163,
+      "instanceId": 0.07556029294614985,
       "skip": false,
       "$$hashKey": "object:33625",
       "outputMeasure": true,
@@ -16929,13 +16681,13 @@
       "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/SimulationOutputReport",
       "uid": "fc337100-8634-404e-8966-01243d292a79",
       "uuid": "{fc337100-8634-404e-8966-01243d292a79}",
-      "version_id": "452c3c75-928b-4c49-93f5-dc319088b009",
-      "version_uuid": "{452c3c75-928b-4c49-93f5-dc319088b009}",
-      "version_modified": "20191210T220251Z",
+      "version_id": "2992ab1b-5569-465c-a32b-c622a453a3cb",
+      "version_uuid": "{2992ab1b-5569-465c-a32b-c622a453a3cb}",
+      "version_modified": "20200123T175728Z",
       "xml_checksum": "2C8A3EEF",
       "display_name": "Simulation Output Report",
       "class_name": "SimulationOutputReport",
-      "description": "Reports simulation outputs of interest.",
+      "description": "Reports simulation ou tputs of interest.",
       "modeler_description": "Change me",
       "tags": "Reporting.QAQC",
       "outputs": [
@@ -16946,7 +16698,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37935",
+          "$$hashKey": "object:36505",
           "checked": true,
           "visualize": "true"
         },
@@ -16957,7 +16709,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37936",
+          "$$hashKey": "object:36506",
           "checked": true,
           "visualize": "true"
         },
@@ -16968,7 +16720,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37937",
+          "$$hashKey": "object:36507",
           "checked": true,
           "visualize": "true"
         },
@@ -16979,7 +16731,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37938",
+          "$$hashKey": "object:36508",
           "checked": true,
           "visualize": "true"
         },
@@ -16990,7 +16742,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37939",
+          "$$hashKey": "object:36509",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "total_site_wood_mbtu",
+          "display_name": "total_site_wood_mbtu",
+          "short_name": "total_site_wood_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36510",
           "checked": true,
           "visualize": "true"
         },
@@ -17001,7 +16764,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37940",
+          "$$hashKey": "object:36511",
           "checked": true,
           "visualize": "true"
         },
@@ -17012,7 +16775,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37941",
+          "$$hashKey": "object:36512",
           "checked": true,
           "visualize": "true"
         },
@@ -17023,7 +16786,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37942",
+          "$$hashKey": "object:36513",
           "checked": true,
           "visualize": "true"
         },
@@ -17034,7 +16797,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37943",
+          "$$hashKey": "object:36514",
           "checked": true,
           "visualize": "true"
         },
@@ -17045,7 +16808,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37944",
+          "$$hashKey": "object:36515",
           "checked": true,
           "visualize": "true"
         },
@@ -17056,7 +16819,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37945",
+          "$$hashKey": "object:36516",
           "checked": true,
           "visualize": "true"
         },
@@ -17067,7 +16830,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37946",
+          "$$hashKey": "object:36517",
           "checked": true,
           "visualize": "true"
         },
@@ -17078,7 +16841,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37947",
+          "$$hashKey": "object:36518",
           "checked": true,
           "visualize": "true"
         },
@@ -17089,7 +16852,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37948",
+          "$$hashKey": "object:36519",
           "checked": true,
           "visualize": "true"
         },
@@ -17100,7 +16863,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37949",
+          "$$hashKey": "object:36520",
           "checked": true,
           "visualize": "true"
         },
@@ -17111,7 +16874,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37950",
+          "$$hashKey": "object:36521",
           "checked": true,
           "visualize": "true"
         },
@@ -17122,7 +16885,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37951",
+          "$$hashKey": "object:36522",
           "checked": true,
           "visualize": "true"
         },
@@ -17133,7 +16896,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37952",
+          "$$hashKey": "object:36523",
           "checked": true,
           "visualize": "true"
         },
@@ -17144,7 +16907,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37953",
+          "$$hashKey": "object:36524",
           "checked": true,
           "visualize": "true"
         },
@@ -17155,7 +16918,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37954",
+          "$$hashKey": "object:36525",
           "checked": true,
           "visualize": "true"
         },
@@ -17166,7 +16929,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37955",
+          "$$hashKey": "object:36526",
           "checked": true,
           "visualize": "true"
         },
@@ -17177,7 +16940,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37956",
+          "$$hashKey": "object:36527",
           "checked": true,
           "visualize": "true"
         },
@@ -17188,7 +16951,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37957",
+          "$$hashKey": "object:36528",
           "checked": true,
           "visualize": "true"
         },
@@ -17199,7 +16962,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37958",
+          "$$hashKey": "object:36529",
           "checked": true,
           "visualize": "true"
         },
@@ -17210,7 +16973,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37959",
+          "$$hashKey": "object:36530",
           "checked": true,
           "visualize": "true"
         },
@@ -17221,7 +16984,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37960",
+          "$$hashKey": "object:36531",
           "checked": true,
           "visualize": "true"
         },
@@ -17232,7 +16995,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37961",
+          "$$hashKey": "object:36532",
           "checked": true,
           "visualize": "true"
         },
@@ -17243,7 +17006,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37962",
+          "$$hashKey": "object:36533",
           "checked": true,
           "visualize": "true"
         },
@@ -17254,7 +17017,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37963",
+          "$$hashKey": "object:36534",
           "checked": true,
           "visualize": "true"
         },
@@ -17265,7 +17028,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37964",
+          "$$hashKey": "object:36535",
           "checked": true,
           "visualize": "true"
         },
@@ -17276,7 +17039,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37965",
+          "$$hashKey": "object:36536",
           "checked": true,
           "visualize": "true"
         },
@@ -17287,7 +17050,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37966",
+          "$$hashKey": "object:36537",
           "checked": true,
           "visualize": "true"
         },
@@ -17298,7 +17061,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37967",
+          "$$hashKey": "object:36538",
           "checked": true,
           "visualize": "true"
         },
@@ -17309,7 +17072,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37968",
+          "$$hashKey": "object:36539",
           "checked": true,
           "visualize": "true"
         },
@@ -17320,7 +17083,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37969",
+          "$$hashKey": "object:36540",
           "checked": true,
           "visualize": "true"
         },
@@ -17331,7 +17094,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37970",
+          "$$hashKey": "object:36541",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "wood_heating_mbtu",
+          "display_name": "wood_heating_mbtu",
+          "short_name": "wood_heating_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36542",
           "checked": true,
           "visualize": "true"
         },
@@ -17342,7 +17116,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37971",
+          "$$hashKey": "object:36543",
           "checked": true,
           "visualize": "true"
         },
@@ -17353,7 +17127,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37972",
+          "$$hashKey": "object:36544",
           "checked": true,
           "visualize": "true"
         },
@@ -17364,7 +17138,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37973",
+          "$$hashKey": "object:36545",
           "checked": true,
           "visualize": "true"
         },
@@ -17375,7 +17149,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37974",
+          "$$hashKey": "object:36546",
           "checked": true,
           "visualize": "true"
         },
@@ -17386,7 +17160,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37975",
+          "$$hashKey": "object:36547",
           "checked": true,
           "visualize": "true"
         },
@@ -17397,7 +17171,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37976",
+          "$$hashKey": "object:36548",
           "checked": true,
           "visualize": "true"
         },
@@ -17408,7 +17182,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37977",
+          "$$hashKey": "object:36549",
           "checked": true,
           "visualize": "true"
         },
@@ -17419,7 +17193,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37978",
+          "$$hashKey": "object:36550",
           "checked": true,
           "visualize": "true"
         },
@@ -17430,7 +17204,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37979",
+          "$$hashKey": "object:36551",
           "checked": true,
           "visualize": "true"
         },
@@ -17441,7 +17215,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37980",
+          "$$hashKey": "object:36552",
           "checked": true,
           "visualize": "true"
         },
@@ -17452,7 +17226,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37981",
+          "$$hashKey": "object:36553",
           "checked": true,
           "visualize": "true"
         },
@@ -17463,7 +17237,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37982",
+          "$$hashKey": "object:36554",
           "checked": true,
           "visualize": "true"
         },
@@ -17474,7 +17248,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37983",
+          "$$hashKey": "object:36555",
           "checked": true,
           "visualize": "true"
         },
@@ -17485,7 +17259,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37984",
+          "$$hashKey": "object:36556",
           "checked": true,
           "visualize": "true"
         },
@@ -17496,7 +17270,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37985",
+          "$$hashKey": "object:36557",
           "checked": true,
           "visualize": "true"
         },
@@ -17507,7 +17281,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37986",
+          "$$hashKey": "object:36558",
           "checked": true,
           "visualize": "true"
         },
@@ -17518,7 +17292,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37987",
+          "$$hashKey": "object:36559",
           "checked": true,
           "visualize": "true"
         },
@@ -17529,7 +17303,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37988",
+          "$$hashKey": "object:36560",
           "checked": true,
           "visualize": "true"
         },
@@ -17540,7 +17314,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37989",
+          "$$hashKey": "object:36561",
           "checked": true,
           "visualize": "true"
         },
@@ -17551,7 +17325,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37990",
+          "$$hashKey": "object:36562",
           "checked": true,
           "visualize": "true"
         },
@@ -17562,7 +17336,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37991",
+          "$$hashKey": "object:36563",
           "checked": true,
           "visualize": "true"
         },
@@ -17573,7 +17347,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37992",
+          "$$hashKey": "object:36564",
           "checked": true,
           "visualize": "true"
         },
@@ -17584,7 +17358,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37993",
+          "$$hashKey": "object:36565",
           "checked": true,
           "visualize": "true"
         },
@@ -17595,7 +17369,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37994",
+          "$$hashKey": "object:36566",
           "checked": true,
           "visualize": "true"
         },
@@ -17606,7 +17380,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37995",
+          "$$hashKey": "object:36567",
           "checked": true,
           "visualize": "true"
         },
@@ -17617,7 +17391,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37996",
+          "$$hashKey": "object:36568",
           "checked": true,
           "visualize": "true"
         },
@@ -17628,7 +17402,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37997",
+          "$$hashKey": "object:36569",
           "checked": true,
           "visualize": "true"
         },
@@ -17639,7 +17413,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37998",
+          "$$hashKey": "object:36570",
           "checked": true,
           "visualize": "true"
         },
@@ -17650,7 +17424,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37999",
+          "$$hashKey": "object:36571",
           "checked": true,
           "visualize": "true"
         },
@@ -17661,7 +17435,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38000",
+          "$$hashKey": "object:36572",
           "checked": true,
           "visualize": "true"
         },
@@ -17672,7 +17446,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38001",
+          "$$hashKey": "object:36573",
           "checked": true,
           "visualize": "true"
         },
@@ -17683,7 +17457,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38002",
+          "$$hashKey": "object:36574",
           "checked": true,
           "visualize": "true"
         },
@@ -17694,7 +17468,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38003",
+          "$$hashKey": "object:36575",
           "checked": true,
           "visualize": "true"
         },
@@ -17705,7 +17479,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38004",
+          "$$hashKey": "object:36576",
           "checked": true,
           "visualize": "true"
         },
@@ -17716,7 +17490,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38005",
+          "$$hashKey": "object:36577",
           "checked": true,
           "visualize": "true"
         },
@@ -17727,7 +17501,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38006",
+          "$$hashKey": "object:36578",
           "checked": true,
           "visualize": "true"
         },
@@ -17738,7 +17512,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38007",
+          "$$hashKey": "object:36579",
           "checked": true,
           "visualize": "true"
         },
@@ -17749,7 +17523,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38008",
+          "$$hashKey": "object:36580",
           "checked": true,
           "visualize": "true"
         },
@@ -17760,7 +17534,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38009",
+          "$$hashKey": "object:36581",
           "checked": true,
           "visualize": "true"
         },
@@ -17771,7 +17545,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38010",
+          "$$hashKey": "object:36582",
           "checked": true,
           "visualize": "true"
         },
@@ -17782,7 +17556,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38011",
+          "$$hashKey": "object:36583",
           "checked": true,
           "visualize": "true"
         },
@@ -17793,7 +17567,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38012",
+          "$$hashKey": "object:36584",
           "checked": true,
           "visualize": "true"
         },
@@ -17804,7 +17578,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38013",
+          "$$hashKey": "object:36585",
           "checked": true,
           "visualize": "true"
         },
@@ -17815,7 +17589,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38014",
+          "$$hashKey": "object:36586",
           "checked": true,
           "visualize": "true"
         },
@@ -17826,7 +17600,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38015",
+          "$$hashKey": "object:36587",
           "checked": true,
           "visualize": "true"
         },
@@ -17837,7 +17611,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38016",
+          "$$hashKey": "object:36588",
           "checked": true,
           "visualize": "true"
         },
@@ -17848,7 +17622,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38017",
+          "$$hashKey": "object:36589",
           "checked": true,
           "visualize": "true"
         },
@@ -17859,7 +17633,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38018",
+          "$$hashKey": "object:36590",
           "checked": true,
           "visualize": "true"
         },
@@ -17870,7 +17644,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38019",
+          "$$hashKey": "object:36591",
           "checked": true,
           "visualize": "true"
         },
@@ -17881,7 +17655,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38020",
+          "$$hashKey": "object:36592",
           "checked": true,
           "visualize": "true"
         },
@@ -17892,7 +17666,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38021",
+          "$$hashKey": "object:36593",
           "checked": true,
           "visualize": "true"
         },
@@ -17903,7 +17677,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38022",
+          "$$hashKey": "object:36594",
           "checked": true,
           "visualize": "true"
         },
@@ -17914,7 +17688,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38023",
+          "$$hashKey": "object:36595",
           "checked": true,
           "visualize": "true"
         },
@@ -17925,7 +17699,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38024",
+          "$$hashKey": "object:36596",
           "checked": true,
           "visualize": "true"
         },
@@ -17936,7 +17710,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38025",
+          "$$hashKey": "object:36597",
           "checked": true,
           "visualize": "true"
         },
@@ -17947,7 +17721,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38026",
+          "$$hashKey": "object:36598",
           "checked": true,
           "visualize": "true"
         },
@@ -17958,7 +17732,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38027",
+          "$$hashKey": "object:36599",
           "checked": true,
           "visualize": "true"
         },
@@ -17969,7 +17743,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38028",
+          "$$hashKey": "object:36600",
           "checked": true,
           "visualize": "true"
         },
@@ -17980,7 +17754,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38029",
+          "$$hashKey": "object:36601",
           "checked": true,
           "visualize": "true"
         },
@@ -17991,7 +17765,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38030",
+          "$$hashKey": "object:36602",
           "checked": true,
           "visualize": "true"
         },
@@ -18002,7 +17776,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38031",
+          "$$hashKey": "object:36603",
           "checked": true,
           "visualize": "true"
         },
@@ -18013,7 +17787,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38032",
+          "$$hashKey": "object:36604",
           "checked": true,
           "visualize": "true"
         },
@@ -18024,7 +17798,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38033",
+          "$$hashKey": "object:36605",
           "checked": true,
           "visualize": "true"
         },
@@ -18035,7 +17809,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38034",
+          "$$hashKey": "object:36606",
           "checked": true,
           "visualize": "true"
         },
@@ -18046,7 +17820,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38035",
+          "$$hashKey": "object:36607",
           "checked": true,
           "visualize": "true"
         },
@@ -18057,7 +17831,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38036",
+          "$$hashKey": "object:36608",
           "checked": true,
           "visualize": "true"
         },
@@ -18068,7 +17842,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38037",
+          "$$hashKey": "object:36609",
           "checked": true,
           "visualize": "true"
         },
@@ -18079,7 +17853,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38038",
+          "$$hashKey": "object:36610",
           "checked": true,
           "visualize": "true"
         },
@@ -18090,7 +17864,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38039",
+          "$$hashKey": "object:36611",
           "checked": true,
           "visualize": "true"
         },
@@ -18101,7 +17875,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38040",
+          "$$hashKey": "object:36612",
           "checked": true,
           "visualize": "true"
         },
@@ -18112,7 +17886,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:38041",
+          "$$hashKey": "object:36613",
           "checked": true,
           "visualize": "true"
         }
@@ -18137,15 +17911,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "12/10/2019",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 5,
       "options": [],
-      "instanceId": 0.2597170310922814,
+      "instanceId": 0.6005846823618324,
       "skip": false,
-      "$$hashKey": "object:33626",
+      "$$hashKey": "object:33281",
       "outputMeasure": true,
       "userDefinedOutputs": [],
       "analysisOutputs": [
@@ -18156,7 +17930,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37935",
+          "$$hashKey": "object:36505",
           "checked": true,
           "visualize": "true"
         },
@@ -18167,7 +17941,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37936",
+          "$$hashKey": "object:36506",
           "checked": true,
           "visualize": "true"
         },
@@ -18178,7 +17952,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37937",
+          "$$hashKey": "object:36507",
           "checked": true,
           "visualize": "true"
         },
@@ -18189,7 +17963,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37938",
+          "$$hashKey": "object:36508",
           "checked": true,
           "visualize": "true"
         },
@@ -18200,7 +17974,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37939",
+          "$$hashKey": "object:36509",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "total_site_wood_mbtu",
+          "display_name": "total_site_wood_mbtu",
+          "short_name": "total_site_wood_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36510",
           "checked": true,
           "visualize": "true"
         },
@@ -18211,7 +17996,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37940",
+          "$$hashKey": "object:36511",
           "checked": true,
           "visualize": "true"
         },
@@ -18222,7 +18007,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37941",
+          "$$hashKey": "object:36512",
           "checked": true,
           "visualize": "true"
         },
@@ -18233,7 +18018,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37942",
+          "$$hashKey": "object:36513",
           "checked": true,
           "visualize": "true"
         },
@@ -18244,7 +18029,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37943",
+          "$$hashKey": "object:36514",
           "checked": true,
           "visualize": "true"
         },
@@ -18255,7 +18040,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37944",
+          "$$hashKey": "object:36515",
           "checked": true,
           "visualize": "true"
         },
@@ -18266,7 +18051,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37945",
+          "$$hashKey": "object:36516",
           "checked": true,
           "visualize": "true"
         },
@@ -18277,7 +18062,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37946",
+          "$$hashKey": "object:36517",
           "checked": true,
           "visualize": "true"
         },
@@ -18288,7 +18073,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37947",
+          "$$hashKey": "object:36518",
           "checked": true,
           "visualize": "true"
         },
@@ -18299,7 +18084,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37948",
+          "$$hashKey": "object:36519",
           "checked": true,
           "visualize": "true"
         },
@@ -18310,7 +18095,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37949",
+          "$$hashKey": "object:36520",
           "checked": true,
           "visualize": "true"
         },
@@ -18321,7 +18106,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37950",
+          "$$hashKey": "object:36521",
           "checked": true,
           "visualize": "true"
         },
@@ -18332,7 +18117,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37951",
+          "$$hashKey": "object:36522",
           "checked": true,
           "visualize": "true"
         },
@@ -18343,7 +18128,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37952",
+          "$$hashKey": "object:36523",
           "checked": true,
           "visualize": "true"
         },
@@ -18354,7 +18139,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37953",
+          "$$hashKey": "object:36524",
           "checked": true,
           "visualize": "true"
         },
@@ -18365,7 +18150,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37954",
+          "$$hashKey": "object:36525",
           "checked": true,
           "visualize": "true"
         },
@@ -18376,7 +18161,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37955",
+          "$$hashKey": "object:36526",
           "checked": true,
           "visualize": "true"
         },
@@ -18387,7 +18172,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37956",
+          "$$hashKey": "object:36527",
           "checked": true,
           "visualize": "true"
         },
@@ -18398,7 +18183,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37957",
+          "$$hashKey": "object:36528",
           "checked": true,
           "visualize": "true"
         },
@@ -18409,7 +18194,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37958",
+          "$$hashKey": "object:36529",
           "checked": true,
           "visualize": "true"
         },
@@ -18420,7 +18205,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37959",
+          "$$hashKey": "object:36530",
           "checked": true,
           "visualize": "true"
         },
@@ -18431,7 +18216,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37960",
+          "$$hashKey": "object:36531",
           "checked": true,
           "visualize": "true"
         },
@@ -18442,7 +18227,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37961",
+          "$$hashKey": "object:36532",
           "checked": true,
           "visualize": "true"
         },
@@ -18453,7 +18238,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37962",
+          "$$hashKey": "object:36533",
           "checked": true,
           "visualize": "true"
         },
@@ -18464,7 +18249,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37963",
+          "$$hashKey": "object:36534",
           "checked": true,
           "visualize": "true"
         },
@@ -18475,7 +18260,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37964",
+          "$$hashKey": "object:36535",
           "checked": true,
           "visualize": "true"
         },
@@ -18486,7 +18271,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37965",
+          "$$hashKey": "object:36536",
           "checked": true,
           "visualize": "true"
         },
@@ -18497,7 +18282,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37966",
+          "$$hashKey": "object:36537",
           "checked": true,
           "visualize": "true"
         },
@@ -18508,7 +18293,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37967",
+          "$$hashKey": "object:36538",
           "checked": true,
           "visualize": "true"
         },
@@ -18519,7 +18304,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37968",
+          "$$hashKey": "object:36539",
           "checked": true,
           "visualize": "true"
         },
@@ -18530,7 +18315,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37969",
+          "$$hashKey": "object:36540",
           "checked": true,
           "visualize": "true"
         },
@@ -18541,7 +18326,18 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37970",
+          "$$hashKey": "object:36541",
+          "checked": true,
+          "visualize": "true"
+        },
+        {
+          "name": "wood_heating_mbtu",
+          "display_name": "wood_heating_mbtu",
+          "short_name": "wood_heating_mbtu",
+          "description": "",
+          "type": "Double",
+          "model_dependent": false,
+          "$$hashKey": "object:36542",
           "checked": true,
           "visualize": "true"
         },
@@ -18552,7 +18348,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37971",
+          "$$hashKey": "object:36543",
           "checked": true,
           "visualize": "true"
         },
@@ -18563,7 +18359,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37972",
+          "$$hashKey": "object:36544",
           "checked": true,
           "visualize": "true"
         },
@@ -18574,7 +18370,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37973",
+          "$$hashKey": "object:36545",
           "checked": true,
           "visualize": "true"
         },
@@ -18585,7 +18381,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37974",
+          "$$hashKey": "object:36546",
           "checked": true,
           "visualize": "true"
         },
@@ -18596,7 +18392,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37975",
+          "$$hashKey": "object:36547",
           "checked": true,
           "visualize": "true"
         },
@@ -18607,7 +18403,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37976",
+          "$$hashKey": "object:36548",
           "checked": true,
           "visualize": "true"
         },
@@ -18618,7 +18414,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37977",
+          "$$hashKey": "object:36549",
           "checked": true,
           "visualize": "true"
         },
@@ -18629,7 +18425,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37978",
+          "$$hashKey": "object:36550",
           "checked": true,
           "visualize": "true"
         },
@@ -18640,7 +18436,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37979",
+          "$$hashKey": "object:36551",
           "checked": true,
           "visualize": "true"
         },
@@ -18651,7 +18447,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37980",
+          "$$hashKey": "object:36552",
           "checked": true,
           "visualize": "true"
         },
@@ -18662,7 +18458,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37981",
+          "$$hashKey": "object:36553",
           "checked": true,
           "visualize": "true"
         },
@@ -18673,7 +18469,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37982",
+          "$$hashKey": "object:36554",
           "checked": true,
           "visualize": "true"
         },
@@ -18684,7 +18480,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37983",
+          "$$hashKey": "object:36555",
           "checked": true,
           "visualize": "true"
         },
@@ -18695,7 +18491,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37984",
+          "$$hashKey": "object:36556",
           "checked": true,
           "visualize": "true"
         },
@@ -18706,7 +18502,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37985",
+          "$$hashKey": "object:36557",
           "checked": true,
           "visualize": "true"
         },
@@ -18717,7 +18513,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37986",
+          "$$hashKey": "object:36558",
           "checked": true,
           "visualize": "true"
         },
@@ -18728,7 +18524,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37987",
+          "$$hashKey": "object:36559",
           "checked": true,
           "visualize": "true"
         },
@@ -18739,7 +18535,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37988",
+          "$$hashKey": "object:36560",
           "checked": true,
           "visualize": "true"
         },
@@ -18750,7 +18546,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37989",
+          "$$hashKey": "object:36561",
           "checked": true,
           "visualize": "true"
         },
@@ -18761,7 +18557,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37990",
+          "$$hashKey": "object:36562",
           "checked": true,
           "visualize": "true"
         },
@@ -18772,7 +18568,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37991",
+          "$$hashKey": "object:36563",
           "checked": true,
           "visualize": "true"
         },
@@ -18783,7 +18579,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37992",
+          "$$hashKey": "object:36564",
           "checked": true,
           "visualize": "true"
         },
@@ -18794,7 +18590,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37993",
+          "$$hashKey": "object:36565",
           "checked": true,
           "visualize": "true"
         },
@@ -18805,7 +18601,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37994",
+          "$$hashKey": "object:36566",
           "checked": true,
           "visualize": "true"
         },
@@ -18816,7 +18612,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37995",
+          "$$hashKey": "object:36567",
           "checked": true,
           "visualize": "true"
         },
@@ -18827,7 +18623,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37996",
+          "$$hashKey": "object:36568",
           "checked": true,
           "visualize": "true"
         },
@@ -18838,7 +18634,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37997",
+          "$$hashKey": "object:36569",
           "checked": true,
           "visualize": "true"
         },
@@ -18849,7 +18645,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37998",
+          "$$hashKey": "object:36570",
           "checked": true,
           "visualize": "true"
         },
@@ -18860,7 +18656,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:37999",
+          "$$hashKey": "object:36571",
           "checked": true,
           "visualize": "true"
         },
@@ -18871,7 +18667,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38000",
+          "$$hashKey": "object:36572",
           "checked": true,
           "visualize": "true"
         },
@@ -18882,7 +18678,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38001",
+          "$$hashKey": "object:36573",
           "checked": true,
           "visualize": "true"
         },
@@ -18893,7 +18689,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38002",
+          "$$hashKey": "object:36574",
           "checked": true,
           "visualize": "true"
         },
@@ -18904,7 +18700,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38003",
+          "$$hashKey": "object:36575",
           "checked": true,
           "visualize": "true"
         },
@@ -18915,7 +18711,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38004",
+          "$$hashKey": "object:36576",
           "checked": true,
           "visualize": "true"
         },
@@ -18926,7 +18722,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38005",
+          "$$hashKey": "object:36577",
           "checked": true,
           "visualize": "true"
         },
@@ -18937,7 +18733,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38006",
+          "$$hashKey": "object:36578",
           "checked": true,
           "visualize": "true"
         },
@@ -18948,7 +18744,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38007",
+          "$$hashKey": "object:36579",
           "checked": true,
           "visualize": "true"
         },
@@ -18959,7 +18755,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38008",
+          "$$hashKey": "object:36580",
           "checked": true,
           "visualize": "true"
         },
@@ -18970,7 +18766,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38009",
+          "$$hashKey": "object:36581",
           "checked": true,
           "visualize": "true"
         },
@@ -18981,7 +18777,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38010",
+          "$$hashKey": "object:36582",
           "checked": true,
           "visualize": "true"
         },
@@ -18992,7 +18788,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38011",
+          "$$hashKey": "object:36583",
           "checked": true,
           "visualize": "true"
         },
@@ -19003,7 +18799,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38012",
+          "$$hashKey": "object:36584",
           "checked": true,
           "visualize": "true"
         },
@@ -19014,7 +18810,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38013",
+          "$$hashKey": "object:36585",
           "checked": true,
           "visualize": "true"
         },
@@ -19025,7 +18821,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38014",
+          "$$hashKey": "object:36586",
           "checked": true,
           "visualize": "true"
         },
@@ -19036,7 +18832,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38015",
+          "$$hashKey": "object:36587",
           "checked": true,
           "visualize": "true"
         },
@@ -19047,7 +18843,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38016",
+          "$$hashKey": "object:36588",
           "checked": true,
           "visualize": "true"
         },
@@ -19058,7 +18854,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38017",
+          "$$hashKey": "object:36589",
           "checked": true,
           "visualize": "true"
         },
@@ -19069,7 +18865,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38018",
+          "$$hashKey": "object:36590",
           "checked": true,
           "visualize": "true"
         },
@@ -19080,7 +18876,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38019",
+          "$$hashKey": "object:36591",
           "checked": true,
           "visualize": "true"
         },
@@ -19091,7 +18887,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38020",
+          "$$hashKey": "object:36592",
           "checked": true,
           "visualize": "true"
         },
@@ -19102,7 +18898,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38021",
+          "$$hashKey": "object:36593",
           "checked": true,
           "visualize": "true"
         },
@@ -19113,7 +18909,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38022",
+          "$$hashKey": "object:36594",
           "checked": true,
           "visualize": "true"
         },
@@ -19124,7 +18920,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38023",
+          "$$hashKey": "object:36595",
           "checked": true,
           "visualize": "true"
         },
@@ -19135,7 +18931,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38024",
+          "$$hashKey": "object:36596",
           "checked": true,
           "visualize": "true"
         },
@@ -19146,7 +18942,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38025",
+          "$$hashKey": "object:36597",
           "checked": true,
           "visualize": "true"
         },
@@ -19157,7 +18953,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38026",
+          "$$hashKey": "object:36598",
           "checked": true,
           "visualize": "true"
         },
@@ -19168,7 +18964,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38027",
+          "$$hashKey": "object:36599",
           "checked": true,
           "visualize": "true"
         },
@@ -19179,7 +18975,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38028",
+          "$$hashKey": "object:36600",
           "checked": true,
           "visualize": "true"
         },
@@ -19190,7 +18986,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38029",
+          "$$hashKey": "object:36601",
           "checked": true,
           "visualize": "true"
         },
@@ -19201,7 +18997,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38030",
+          "$$hashKey": "object:36602",
           "checked": true,
           "visualize": "true"
         },
@@ -19212,7 +19008,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38031",
+          "$$hashKey": "object:36603",
           "checked": true,
           "visualize": "true"
         },
@@ -19223,7 +19019,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38032",
+          "$$hashKey": "object:36604",
           "checked": true,
           "visualize": "true"
         },
@@ -19234,7 +19030,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38033",
+          "$$hashKey": "object:36605",
           "checked": true,
           "visualize": "true"
         },
@@ -19245,7 +19041,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38034",
+          "$$hashKey": "object:36606",
           "checked": true,
           "visualize": "true"
         },
@@ -19256,7 +19052,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38035",
+          "$$hashKey": "object:36607",
           "checked": true,
           "visualize": "true"
         },
@@ -19267,7 +19063,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38036",
+          "$$hashKey": "object:36608",
           "checked": true,
           "visualize": "true"
         },
@@ -19278,7 +19074,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38037",
+          "$$hashKey": "object:36609",
           "checked": true,
           "visualize": "true"
         },
@@ -19289,7 +19085,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38038",
+          "$$hashKey": "object:36610",
           "checked": true,
           "visualize": "true"
         },
@@ -19300,7 +19096,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38039",
+          "$$hashKey": "object:36611",
           "checked": true,
           "visualize": "true"
         },
@@ -19311,7 +19107,7 @@
           "description": "",
           "type": "Double",
           "model_dependent": false,
-          "$$hashKey": "object:38040",
+          "$$hashKey": "object:36612",
           "checked": true,
           "visualize": "true"
         },
@@ -19322,7 +19118,7 @@
           "description": "",
           "type": "String",
           "model_dependent": false,
-          "$$hashKey": "object:38041",
+          "$$hashKey": "object:36613",
           "checked": true,
           "visualize": "true"
         }
@@ -19331,12 +19127,12 @@
     {
       "measure_dir": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\TimeseriesCSVExport",
       "name": "timeseries_csv_export",
-      "directory": "C:\\OpenStudio\\OpenStudio-BuildStock\\project_testing\\measures\\TimeseriesCSVExport",
+      "directory": "C:/OpenStudio/OpenStudio-BuildStock/measures/TimeseriesCSVExport",
       "uid": "2a3442c1-944d-4e91-9e11-11e0cf368c64",
       "uuid": "{2a3442c1-944d-4e91-9e11-11e0cf368c64}",
-      "version_id": "64696f29-6d80-4418-b20d-61f5bdff5495",
-      "version_uuid": "{64696f29-6d80-4418-b20d-61f5bdff5495}",
-      "version_modified": "20191210T220251Z",
+      "version_id": "cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03",
+      "version_uuid": "{cb8fd65a-1c4d-45bd-97bd-0d535d4f0c03}",
+      "version_modified": "20200123T180929Z",
       "xml_checksum": "15BF4E57",
       "display_name": "Timeseries CSV Export",
       "class_name": "TimeseriesCSVExport",
@@ -19391,7 +19187,7 @@
             "stdDev": "Hourly",
             "default_value": "Hourly"
           },
-          "$$hashKey": "object:13640"
+          "$$hashKey": "object:33339"
         },
         {
           "name": "include_enduse_subcategories",
@@ -19415,7 +19211,7 @@
             "stdDev": false,
             "default_value": false
           },
-          "$$hashKey": "object:13641"
+          "$$hashKey": "object:33340"
         },
         {
           "name": "output_variables",
@@ -19438,7 +19234,7 @@
             "stdDev": "",
             "default_value": ""
           },
-          "$$hashKey": "object:13642"
+          "$$hashKey": "object:33341"
         }
       ],
       "edit": "",
@@ -19448,15 +19244,15 @@
       "add": "",
       "open": false,
       "addedToProject": true,
-      "date": "12/10/2019",
+      "date": "1/23/2020",
       "author": "",
       "type": "ReportingMeasure",
       "seed": "EmptySeedModel.osm",
       "workflow_index": 6,
       "options": [],
-      "instanceId": 0.9803814100282344,
+      "instanceId": 0.2528069340970671,
       "skip": false,
-      "$$hashKey": "object:13581",
+      "$$hashKey": "object:33280",
       "outputMeasure": false
     },
     {
@@ -19501,7 +19297,7 @@
       "seed": "EmptySeedModel.osm",
       "workflow_index": 7,
       "options": [],
-      "instanceId": 0.7421755757714481,
+      "instanceId": 0.634063841888304,
       "skip": false,
       "$$hashKey": "object:512021",
       "outputMeasure": false

--- a/resources/measures/HPXMLtoOpenStudio/measure.xml
+++ b/resources/measures/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxml_translator</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>5236fdd4-f007-4084-925a-3647a1fbfcbb</version_id>
-  <version_modified>20191210T204902Z</version_modified>
+  <version_id>2a18960b-0de3-44b6-b266-5efe3c9d6831</version_id>
+  <version_modified>20200123T175730Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLTranslator</class_name>
   <display_name>HPXML Translator</display_name>
@@ -481,7 +481,7 @@
       <filename>util.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>50A06C8F</checksum>
+      <checksum>8DDF2E0D</checksum>
     </file>
   </files>
 </measure>

--- a/resources/measures/HPXMLtoOpenStudio/resources/util.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/util.rb
@@ -719,6 +719,36 @@ class OutputMeters
     return @propane
   end
 
+  def wood(sql_file, ann_env_pd)
+    env_period_ix_query = "SELECT EnvironmentPeriodIndex FROM EnvironmentPeriods WHERE EnvironmentName='#{ann_env_pd}'"
+    env_period_ix = sql_file.execAndReturnFirstInt(env_period_ix_query).get
+    num_ts = get_num_ts(sql_file)
+
+    # Get meters that are tied to units, and apportion building level meters to these
+    woodHeating = Vector.elements(Array.new(num_ts, 0.0))
+
+    # Get building units
+    units = Geometry.get_building_units(@model, @runner)
+    if units.nil?
+      return false
+    end
+
+    units.each do |unit|
+      unit_name = unit.name.to_s.upcase
+      units_represented = get_units_represented(unit)
+
+      woodHeating = add_unit(sql_file, woodHeating, units_represented, "SELECT VariableValue/1000000000 FROM ReportMeterData WHERE ReportMeterDataDictionaryIndex IN (SELECT ReportMeterDataDictionaryIndex FROM ReportMeterDataDictionary WHERE VariableType='Sum' AND VariableName IN ('#{unit_name}:WOODHEATING') AND ReportingFrequency='#{@reporting_frequency_eplus}' AND VariableUnits='J') AND TimeIndex IN (SELECT TimeIndex FROM Time WHERE EnvironmentPeriodIndex='#{env_period_ix}')")
+    end
+
+    @wood = Wood.new
+
+    @wood.heating = woodHeating
+
+    @wood.total_end_uses = @wood.heating
+
+    return @wood
+  end
+
   def hours_setpoint_not_met(sql_file)
     # Get meters that are tied to units, and apportion building level meters to these
     hoursHeatingSetpointNotMet = 0.0
@@ -838,6 +868,7 @@ class OutputMeters
       propane_heating(custom_meter_infos, unit, thermal_zones)
       propane_interior_equipment(custom_meter_infos, unit, thermal_zones)
       propane_water_systems(custom_meter_infos, unit, thermal_zones)
+      wood_heating(custom_meter_infos, unit, thermal_zones)
 
       if @include_enduse_subcategories
         electricity_refrigerator(custom_meter_infos, unit, thermal_zones)
@@ -1579,6 +1610,24 @@ class OutputMeters
     end
   end
 
+  def wood_heating(custom_meter_infos, unit, thermal_zones)
+    custom_meter_infos["#{unit.name}:WoodHeating"] = { "fuel_type" => "OtherFuel1", "key_var_groups" => [] }
+    thermal_zones.each do |thermal_zone|
+      heating_equipment = HVAC.existing_heating_equipment(@model, @runner, thermal_zone)
+      heating_equipment.each do |htg_equip|
+        clg_coil, htg_coil, supp_htg_coil = HVAC.get_coils_from_hvac_equip(htg_equip)
+
+        if htg_equip.is_a? OpenStudio::Model::AirLoopHVACUnitarySystem
+          if htg_coil.is_a? OpenStudio::Model::CoilHeatingGas
+            next if htg_coil.fuelType != "OtherFuel1"
+          end
+
+          custom_meter_infos["#{unit.name}:WoodHeating"]["key_var_groups"] << ["#{htg_coil.name}", "Heating Coil OtherFuel1 Energy"]
+        end
+      end
+    end
+  end
+
   def electricity_refrigerator(custom_meter_infos, unit, thermal_zones)
     custom_meter_infos["#{unit.name}:ElectricityRefrigerator"] = { "fuel_type" => "Electricity", "key_var_groups" => [] }
     unit.spaces.each do |space|
@@ -1961,6 +2010,12 @@ class Propane
   def initialize
   end
   attr_accessor :heating, :central_heating, :interior_equipment, :water_systems, :clothes_dryer, :cooking_range, :total_end_uses
+end
+
+class Wood
+  def initialize
+  end
+  attr_accessor :heating, :total_end_uses
 end
 
 class HoursSetpointNotMet

--- a/resources/options_lookup.tsv
+++ b/resources/options_lookup.tsv
@@ -1495,6 +1495,7 @@ HVAC System Heating Fuel Oil	Oil Boiler	ResidentialHVACBoiler	fuel_type=oil	"sys
 HVAC System Heating Wood	None																																														
 HVAC System Heating Wood	Wood Stove	ResidentialHVACUnitHeater	fuel_type=wood	efficiency=0.6	fan_power=0	airflow_rate=0	capacity=autosize																																								
 		ResidentialAirflow	has_hvac_flue=true																																												
+		ResidentialHVACSizing	show_debug_info=false																																												
 HVAC System Heating Other Fuel	None																																														
 HVAC System Heating None	None																																														
 HVAC System Cooling	None																																														


### PR DESCRIPTION
Reported at https://unmethours.com/question/42433/some-upgrade-options-arent-compatible-with-resstock/

I added a bugfix for the upgrade so that the EnergyPlus simulation is successful. 

However, the upgrade is still failing because the SimulationOutputReport measure isn't looking at the wood fuel (OtherFuel1). @joseph-robertson, can you update the measure? We only allow wood for space heating in ResStock, so you don't have to handle other end uses. FWIW, here's the error message from run.log:
`[16:06:31.407796 ERROR] Disaggregated total site energy (31.626833704418196 GJ) relative to building total site energy (37.77 GJ): -6.143166295581807 GJ.`