### PR TITLE
fix qoi report measure to handle locations without a season

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features
 - Increase the diversity of the infiltration simulated. Now using the Residential Diagnostics Database for the Infiltration housing characteristic ([#427](https://github.com/NREL/OpenStudio-BuildStock/pull/427)).
 
 Fixes
+- Fix bug in QOI reporting measure where absence of any heating/cooling/overlap seasons would cause errors ([#433](https://github.com/NREL/OpenStudio-BuildStock/pull/433))
 - Restructure unfinished attic and finished roof -related tsv files (i.e., insulation, roof material, and radiant barrier) and options ([#426](https://github.com/NREL/OpenStudio-BuildStock/pull/426))
 - Exclude net site energy consumption from annual and timeseries simulation output ("total" now reflects net of pv); change `include_enduse_subcategories` argument default to "true"; report either total interior equipment OR each of its components ([#405](https://github.com/NREL/OpenStudio-BuildStock/pull/405))
 - Refactor the tsv maker classes to accommodate more data sources ([#392](https://github.com/NREL/OpenStudio-BuildStock/pull/392))

--- a/measures/QOIReport/measure.rb
+++ b/measures/QOIReport/measure.rb
@@ -266,10 +266,15 @@ class QOIReport < OpenStudio::Measure::ReportingMeasure
     end
 
     if top == "all"
-      top = daily_vals.length
+      top = daily_vals["hour"].length
     else
-      top = [top, daily_vals.length].min # don't try to access indexes that don't exist
+      top = [top, daily_vals["hour"].length].min # don't try to access indexes that don't exist
     end
+
+    if top.zero?
+      return nil
+    end
+
     daily_vals["use"], daily_vals["hour"] = daily_vals["use"].zip(daily_vals["hour"]).sort.reverse.transpose
     daily_vals = daily_vals["hour"][0..top]
     return daily_vals.inject { |sum, el| sum + el }.to_f / daily_vals.size

--- a/measures/QOIReport/measure.rb
+++ b/measures/QOIReport/measure.rb
@@ -218,6 +218,16 @@ class QOIReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def average_daily_use(timeseries, temperature_range, min_or_max, top = "all")
+    """
+    Calculates the average of daily base or peak use values during heating, cooling, or overlap seasons.
+    Parameters:
+      timeseries (hash): { 'Temperature' => [...], 'total_site_electricity_kw' => [...] }
+      temperature_range (array): [lower, upper]
+      min_or_max (str): 'min' or 'max'
+      top: integer or 'all'
+    Returns:
+      average_daily_use: float or nil
+    """
     daily_vals = []
     timeseries["total_site_electricity_kw"].each_slice(24).with_index do |kws, i|
       temps = timeseries["Temperature"][(24 * i)...(24 * i + 24)]
@@ -245,6 +255,16 @@ class QOIReport < OpenStudio::Measure::ReportingMeasure
   end
 
   def average_daily_timing(timeseries, temperature_range, min_or_max, top = "all")
+    """
+    Calculates the average hour of daily base or peak use values during heating, cooling, or overlap seasons.
+    Parameters:
+      timeseries (hash): { 'Temperature' => [...], 'total_site_electricity_kw' => [...] }
+      temperature_range (array): [lower, upper]
+      min_or_max (str): 'min' or 'max'
+      top: integer or 'all'
+    Returns:
+      average_daily_use: float or nil
+    """
     daily_vals = { "hour" => [], "use" => [] }
     timeseries["total_site_electricity_kw"].each_slice(24).with_index do |kws, i|
       temps = timeseries["Temperature"][(24 * i)...(24 * i + 24)]

--- a/measures/QOIReport/measure.xml
+++ b/measures/QOIReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>qoi_report</name>
   <uid>be0bfc7f-25c6-435a-9acd-2f5fa8ac817d</uid>
-  <version_id>0900d754-0a23-4786-96d9-ab2b58bf0310</version_id>
-  <version_modified>20191127T165307Z</version_modified>
+  <version_id>6a0fbc3c-f3d3-431b-bd84-713f95e04207</version_id>
+  <version_modified>20200402T023118Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>QOIReport</class_name>
   <display_name>QOI Report</display_name>
@@ -130,7 +130,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>9F01B192</checksum>
+      <checksum>618CD322</checksum>
     </file>
   </files>
 </measure>

--- a/measures/QOIReport/tests/qoi_report_test.rb
+++ b/measures/QOIReport/tests/qoi_report_test.rb
@@ -65,7 +65,7 @@ class QOIReportTest < MiniTest::Test
     assert_in_epsilon(10.0, actual_val, 0.001) # average of 0 and 20
   end
 
-  def test_no_heating_temperatures
+  def test_average_daily_use_base_no_heating_temperatures
     temperature, total_site_electricity_kw = _setup_test
     temperature[0..48] = _daily_cooling_temperatures * 2 # no heating temperatures
     timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
@@ -78,6 +78,111 @@ class QOIReportTest < MiniTest::Test
 
     actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonOverlap], "min")
     assert_in_epsilon(7.5, actual_val, 0.001) # average of 5 and 10
+  end
+
+  def test_average_daily_use_peak_no_heating_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[0..48] = _daily_cooling_temperatures * 2 # no heating temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonHeating], "max")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonCooling], "max")
+    assert_in_epsilon(12.0, actual_val, 0.001) # average of 10, 12, 10, 16
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonOverlap], "max")
+    assert_in_epsilon(14.5, actual_val, 0.001) # average of 10 and 19
+  end
+
+  def test_average_daily_use_base_no_cooling_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[47..96] = _daily_heating_temperatures * 2 # no cooling temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonHeating], "min")
+    assert_in_epsilon(7.0, actual_val, 0.001) # average of 0, 10, 8, and 10
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonCooling], "min")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonOverlap], "min")
+    assert_in_epsilon(7.5, actual_val, 0.001) # average of 5 and 10
+  end
+
+  def test_average_daily_use_peak_no_cooling_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[47..96] = _daily_heating_temperatures * 2 # no cooling temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonHeating], "max")
+    assert_in_epsilon(12.0, actual_val, 0.001) # average of 10, 12, 10, 16
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonCooling], "max")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_use(timeseries, @@measure.seasons[Constants.SeasonOverlap], "max")
+    assert_in_epsilon(14.5, actual_val, 0.001) # average of 10 and 19
+  end
+
+  def test_average_daily_timing_base_no_heating_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[0..48] = _daily_cooling_temperatures * 2 # no heating temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonHeating], "min")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonCooling], "min")
+    assert_in_epsilon(0.75, actual_val, 0.001) # average of 0, 0, 3, and 0
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonOverlap], "min")
+    assert_in_epsilon(5.0, actual_val, 0.001) # average of 10 and 0
+  end
+
+  def test_average_daily_timing_peak_no_heating_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[0..48] = _daily_cooling_temperatures * 2 # no heating temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonHeating], "max")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonCooling], "max")
+    assert_in_epsilon(4.5, actual_val, 0.001) # average of 1, 4, 0, 13
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonOverlap], "max")
+    assert_in_epsilon(10.0, actual_val, 0.001) # average of 0 and 20
+  end
+
+  def test_average_daily_timing_base_no_cooling_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[47..96] = _daily_heating_temperatures * 2 # no cooling temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonHeating], "min")
+    assert_in_epsilon(0.75, actual_val, 0.001) # average of 0, 0, 3, and 0
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonCooling], "min")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonOverlap], "min")
+    assert_in_epsilon(5.0, actual_val, 0.001) # average of 10 and 0
+  end
+
+  def test_average_daily_timing_peak_no_cooling_temperatures
+    temperature, total_site_electricity_kw = _setup_test
+    temperature[47..96] = _daily_heating_temperatures * 2 # no cooling temperatures
+    timeseries = { "Temperature" => temperature, "total_site_electricity_kw" => total_site_electricity_kw }
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonHeating], "max")
+    assert_in_epsilon(4.5, actual_val, 0.001) # average of 1, 4, 0, 13
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonCooling], "max")
+    assert actual_val.nil?
+
+    actual_val = @@measure.average_daily_timing(timeseries, @@measure.seasons[Constants.SeasonOverlap], "max")
+    assert_in_epsilon(10.0, actual_val, 0.001) # average of 0 and 20
   end
 
   def _setup_test


### PR DESCRIPTION
The QOI report measure timing section has two errors:
1) If there are no days with mean daily temperature above 70F (summer), the measure will fail, as the summer season does not exist.  Common in climate zones 7+
2) The daily_vals object is comprised of two arrays, and the intent is to get the array length. This fixes the timing reporting in the measure.

I did not update measure tests to account for this in this version of the measure, but did so in the ComStock adaptation here: https://github.com/NREL/ComStock-Measures/tree/comstock_sensitivity_reports/measures/qoi_report

Addresses #[issue number here].

## Pull Request Description

[description here]

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).