### PR TITLE
Add rbenv version file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ faraday.log
 *.pydevproject
 *.pyc
 Gemfile.lock
+.ruby-version
 
 coverage
 /test/reports


### PR DESCRIPTION
## Pull Request Description

Add `.ruby-version` to gitignore.

## Checklist

Not all may apply:

- [x] No unexpected regression test changes
- [x] All tests are passing (green) on circleci
- [x] This branch is up-to-date with master