### PR TITLE
Update dependency wheel link url [skip ci]

### DIFF
--- a/project_multifamily_beta/README.md
+++ b/project_multifamily_beta/README.md
@@ -6,7 +6,7 @@ This folder contains the ResStock inputs to model the national residential build
 
 ResStock is built upon the conditional probabilites of the housing characteristics.  Each housing characteristic has a set of dependencies and dependants.  An interactive dependency and dependents visualization is provided in the links below:
 
-<a href="http://htmlpreview.github.io/?https://github.com/NREL/OpenStudio-BuildStock/blob/dep_graph_wheel/project_multifamily_beta/util/dependency_wheel/dep_wheel.html">Multifamily Project: Dependency Wheel</a>
+<a href="https://htmlpreview.github.io/?https://github.com/NREL/OpenStudio-BuildStock/blob/master/project_multifamily_beta/util/dependency_wheel/dep_wheel.html">Multifamily Project: Dependency Wheel</a>
 
 ## Visualization of the Housing Characteristics as a Graph
 


### PR DESCRIPTION
## Pull Request Description

The URL for the dependency wheel is out of date. This PR updates the link in the readme.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).