### PR TITLE
fix bug for small window areas

### DIFF
--- a/resources/measures/ResidentialGeometryWindowSkylightArea/measure.rb
+++ b/resources/measures/ResidentialGeometryWindowSkylightArea/measure.rb
@@ -345,39 +345,41 @@ class SetResidentialWindowSkylightArea < OpenStudio::Measure::ModelMeasure
       end
     end
 
+    # Initialize
     surface_window_area = {}
     target_facade_areas = {}
     facades.each do |facade|
-      # Initialize
+      target_facade_areas[facade] = 0.0
       wall_surfaces[facade].each do |surface|
         surface_window_area[surface] = 0
       end
+    end
 
+    facades.each do |facade|
       # Calculate target window area for this facade
-      target_facade_areas[facade] = 0.0
       if wwrs[facade] > 0
         wall_area = 0
         wall_surfaces[facade].each do |surface|
           wall_area += UnitConversions.convert(surface.grossArea, "m^2", "ft^2")
         end
-        target_facade_areas[facade] = wall_area * wwrs[facade]
+        target_facade_areas[facade] += wall_area * wwrs[facade]
       else
-        target_facade_areas[facade] = window_areas[facade]
+        target_facade_areas[facade] += window_areas[facade]
       end
 
       next if target_facade_areas[facade] == 0
 
       if target_facade_areas[facade] < min_single_window_area
         # If the total window area for the facade is less than the minimum window area,
-        # set all of the window area to the surface with the greatest available wall area
-        surface = my_hash.max_by { |k, v| v }[0]
-        surface_window_area[surface] = target_facade_areas[facade]
+        # set all of the window area to the surface with the greatest available wall area on any facade
+        surface = surface_avail_area.max_by { |k, v| v }[0]
+        surface_window_area[surface] += target_facade_areas[facade]
         next
       end
 
       # Initial guess for wall of this facade
       wall_surfaces[facade].each do |surface|
-        surface_window_area[surface] = surface_avail_area[surface] / facade_avail_area[facade] * target_facade_areas[facade]
+        surface_window_area[surface] += surface_avail_area[surface] / facade_avail_area[facade] * target_facade_areas[facade]
       end
 
       # If window area for a surface is less than the minimum window area,
@@ -413,6 +415,7 @@ class SetResidentialWindowSkylightArea < OpenStudio::Measure::ModelMeasure
         sum_window_area += surface_window_area[surface]
       end
       next if sum_window_area == 0
+      next if target_facade_areas[facade] < sum_window_area # for cases where window area was added from different facade
 
       wall_surfaces[facade].each do |surface|
         surface_window_area[surface] += surface_window_area[surface] / sum_window_area * (target_facade_areas[facade] - sum_window_area)

--- a/resources/measures/ResidentialGeometryWindowSkylightArea/measure.xml
+++ b/resources/measures/ResidentialGeometryWindowSkylightArea/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>set_residential_window_skylight_area</name>
   <uid>d05f5b32-1ad6-4c3d-964a-0dbd49a7fde8</uid>
-  <version_id>d45b34bc-df3c-4ebc-81e8-a15133972cc7</version_id>
-  <version_modified>20190701T173018Z</version_modified>
+  <version_id>49db4fcf-e9bf-4450-aec9-e7dc83c0863c</version_id>
+  <version_modified>20200515T175231Z</version_modified>
   <xml_checksum>9014E219</xml_checksum>
   <class_name>SetResidentialWindowSkylightArea</class_name>
   <display_name>Set Residential Window/Skylight Area</display_name>
@@ -276,13 +276,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>A72C09B1</checksum>
+      <checksum>5E2BF73B</checksum>
     </file>
     <file>
       <filename>WindowSkylightArea_Test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>F8D83C50</checksum>
+      <checksum>ADBDC2B9</checksum>
     </file>
   </files>
 </measure>

--- a/resources/measures/ResidentialGeometryWindowSkylightArea/tests/WindowSkylightArea_Test.rb
+++ b/resources/measures/ResidentialGeometryWindowSkylightArea/tests/WindowSkylightArea_Test.rb
@@ -18,6 +18,19 @@ class WindowSkylightAreaTest < MiniTest::Test
     assert_equal(result.finalCondition.get.logMessage, "No windows or skylights added.")
   end
 
+  def test_below_minimum_window_area
+    args_hash = {}
+    args_hash["front_window_area"] = 5
+    args_hash["front_wwr"] = 0
+    args_hash["back_wwr"] = 0
+    args_hash["left_wwr"] = 0
+    args_hash["right_wwr"] = 0
+    expected_num_del_objects = {}
+    expected_num_new_objects = { "SubSurface" => 1, "ShadingSurface" => 1, "ShadingSurfaceGroup" => 1 }
+    expected_values = { "Constructions" => 0, "OverhangDepth" => 2 }
+    result = _test_measure("SFD_2000sqft_2story_FB_GRG_UA_Southwest.osm", args_hash, [0, 0, 0, 0, 0], [0, 5, 0, 0], [0] * 5, [0] * 5, expected_num_del_objects, expected_num_new_objects, expected_values)
+  end
+
   def test_sfd_new_construction_rotated
     args_hash = {}
     expected_num_del_objects = {}


### PR DESCRIPTION
Fixes #450 

## Pull Request Description

@whiphi92 uncovered a bug that would throw an error when the calculated window area of a facade was less than the minimum allowable window area. This fix checks for that case and applies the invalid window area to the largest available surface.

## Checklist

Not all may apply:

- [X] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).