### PR TITLE
Bugfix for qoi measure

### DIFF
--- a/measures/QOIReport/measure.rb
+++ b/measures/QOIReport/measure.rb
@@ -196,10 +196,10 @@ class QOIReport < OpenStudio::Measure::ReportingMeasure
     timeseries["total_site_electricity_kw"] = electricity.total_end_uses.map { |x| UnitConversions.convert(x, "GJ", "kW", nil, false, output_meters.steps_per_hour) }
 
     # Peak magnitude (1)
-    report_sim_output(runner, "peak_magnitude_use_kw", use(timeseries, [-1e9, 1e9], "max"))
+    report_sim_output(runner, "peak_magnitude_use_kw", use(timeseries, [-1e9, 1e9], "max"), "", "")
 
     # Timing of peak magnitude (1)
-    report_sim_output(runner, "peak_magnitude_timing_kw", timing(timeseries, [-1e9, 1e9], "max"))
+    report_sim_output(runner, "peak_magnitude_timing_kw", timing(timeseries, [-1e9, 1e9], "max"), "", "")
 
     # Average daily base magnitude (by season) (3)
     seasons.each do |season, temperature_range|


### PR DESCRIPTION
## Pull Request Description

Calls to report_sim_output didn't have empty "" assigned to os_units and desired_units arguments.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).