### PR TITLE
Power outage using schedule files, try 2

### DIFF
--- a/measures/PowerOutage/measure.rb
+++ b/measures/PowerOutage/measure.rb
@@ -252,7 +252,7 @@ class ProcessPowerOutage < OpenStudio::Measure::ModelMeasure
       runner.registerInfo("Modified the key name for '#{ems_sensor.name}'.")
     end
 
-    # set the outage on schedules that are generated    
+    # set the outage on schedules that are generated
     schedules_file = SchedulesFile.new(runner: runner, model: model)
     schedules = [
       "cooking_range",
@@ -268,7 +268,7 @@ class ProcessPowerOutage < OpenStudio::Measure::ModelMeasure
       "dishwasher_power",
       "baths",
       "showers",
-      "sinks",      
+      "sinks",
       "ceiling_fan"
     ]
     schedules_path = model.getBuilding.additionalProperties.getFeatureAsString("Schedules Path")

--- a/measures/PowerOutage/measure.rb
+++ b/measures/PowerOutage/measure.rb
@@ -252,6 +252,34 @@ class ProcessPowerOutage < OpenStudio::Measure::ModelMeasure
       runner.registerInfo("Modified the key name for '#{ems_sensor.name}'.")
     end
 
+    # set the outage on schedules that are generated    
+    schedules_file = SchedulesFile.new(runner: runner, model: model)
+    schedules = [
+      "cooking_range",
+      "plug_loads",
+      "lighting_interior",
+      "lighting_exterior",
+      "lighting_garage",
+      "lighting_exterior_holiday",
+      "clothes_washer",
+      "clothes_washer_power",
+      "clothes_dryer",
+      "dishwasher",
+      "dishwasher_power",
+      "baths",
+      "showers",
+      "sinks",      
+      "ceiling_fan"
+    ]
+    schedules_path = model.getBuilding.additionalProperties.getFeatureAsString("Schedules Path")
+    schedules.each do |col_name|
+      if schedules_path.is_initialized # this is not a test
+        schedules_file.import(col_name: col_name)
+        schedules_file.set_outage(col_name: col_name, outage_start_date: otg_date, outage_start_hour: otg_hr, outage_length: otg_len)
+      end
+      runner.registerInfo("Modified the schedule '#{col_name}'.")
+    end
+
     # add additional properties object with the date of the outage for use by reporting measures
     additional_properties = year_description.additionalProperties
     additional_properties.setFeature("PowerOutageStartDate", otg_date)

--- a/measures/PowerOutage/measure.xml
+++ b/measures/PowerOutage/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>process_power_outage</name>
   <uid>6b822ead-80f5-4d8d-9642-25a4e0d74304</uid>
-  <version_id>24b8ab89-68dc-4b34-a9dc-714a1bd9aac8</version_id>
-  <version_modified>20191213T214626Z</version_modified>
+  <version_id>54acb969-8bcd-49fe-9bda-acc7d587c33f</version_id>
+  <version_modified>20200715T232323Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>ProcessPowerOutage</class_name>
   <display_name>Set Residential Power Outage</display_name>
@@ -77,13 +77,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>D3CEEEAE</checksum>
+      <checksum>1E05EE35</checksum>
     </file>
     <file>
       <filename>power_outage_test.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>1075C91F</checksum>
+      <checksum>6A3FED12</checksum>
     </file>
   </files>
 </measure>

--- a/measures/PowerOutage/tests/power_outage_test.rb
+++ b/measures/PowerOutage/tests/power_outage_test.rb
@@ -50,91 +50,83 @@ class OutageTest < MiniTest::Test
   end
 
   def test_outage_less_than_one_day_dst
-    skip
     args_hash = {}
     args_hash["otg_date"] = "June 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 8
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 19, "ScheduleDay" => 19, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 8, "ScheduleDay" => 8, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 24)
+    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 28)
   end
 
   def test_outage_one_day_dst
-    skip
     args_hash = {}
     args_hash["otg_date"] = "June 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 24
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 38, "ScheduleDay" => 38, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 16, "ScheduleDay" => 16, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 24)
+    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 28)
   end
 
   def test_outage_more_than_one_day_dst
-    skip
     args_hash = {}
     args_hash["otg_date"] = "June 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 48
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 57, "ScheduleDay" => 57, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 24, "ScheduleDay" => 24, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 24)
+    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 28)
   end
 
   def test_outage_less_than_one_day
-    skip
     args_hash = {}
     args_hash["otg_date"] = "January 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 8
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 19, "ScheduleDay" => 19, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 8, "ScheduleDay" => 8, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 24)
+    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 28)
   end
 
   def test_outage_one_day
-    skip
     args_hash = {}
     args_hash["otg_date"] = "January 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 24
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 38, "ScheduleDay" => 38, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 16, "ScheduleDay" => 16, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 24)
+    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 28)
   end
 
   def test_outage_more_than_one_day
-    skip
     args_hash = {}
     args_hash["otg_date"] = "January 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 48
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 57, "ScheduleDay" => 57, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 24, "ScheduleDay" => 24, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 24)
+    _test_measure("SFD_Successful_EnergyPlus_Run_TMY.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 28)
   end
 
   def test_outage_less_than_one_day_dst_mf
-    skip
     args_hash = {}
     args_hash["otg_date"] = "June 2"
     args_hash["otg_hr"] = 8
     args_hash["otg_len"] = 8
     expected_num_del_objects = {}
-    expected_num_new_objects = { "ScheduleRule" => 12, "ScheduleDay" => 12, "ScheduleFixedInterval" => 1 }
+    expected_num_new_objects = { "ScheduleRule" => 10, "ScheduleDay" => 10, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("MF_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 14)
+    _test_measure("MF_Successful_EnergyPlus_Run_TMY_Appl_PV.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 27)
   end
 
   def test_outage_short_run_period
-    skip
     args_hash = {}
     args_hash["otg_date"] = "January 23"
     args_hash["otg_hr"] = 20
@@ -142,7 +134,7 @@ class OutageTest < MiniTest::Test
     expected_num_del_objects = {}
     expected_num_new_objects = { "ScheduleRule" => 12, "ScheduleDay" => 12, "ScheduleFixedInterval" => 1 }
     expected_values = {}
-    _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 11)
+    _test_measure("SFD_Successful_EnergyPlus_Run_AMY_PV_TwoDays.osm", args_hash, expected_num_del_objects, expected_num_new_objects, expected_values, 26)
   end
 
   private

--- a/measures/QOIReport/measure.rb
+++ b/measures/QOIReport/measure.rb
@@ -196,10 +196,10 @@ class QOIReport < OpenStudio::Measure::ReportingMeasure
     timeseries["total_site_electricity_kw"] = electricity.total_end_uses.map { |x| UnitConversions.convert(x, "GJ", "kW", nil, false, output_meters.steps_per_hour) }
 
     # Peak magnitude (1)
-    report_sim_output(runner, "peak_magnitude_use_kw", use(timeseries, [-1e9, 1e9], "max"))
+    report_sim_output(runner, "peak_magnitude_use_kw", use(timeseries, [-1e9, 1e9], "max"), "", "")
 
     # Timing of peak magnitude (1)
-    report_sim_output(runner, "peak_magnitude_timing_kw", timing(timeseries, [-1e9, 1e9], "max"))
+    report_sim_output(runner, "peak_magnitude_timing_kw", timing(timeseries, [-1e9, 1e9], "max"), "", "")
 
     # Average daily base magnitude (by season) (3)
     seasons.each do |season, temperature_range|

--- a/measures/QOIReport/measure.xml
+++ b/measures/QOIReport/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>qoi_report</name>
   <uid>be0bfc7f-25c6-435a-9acd-2f5fa8ac817d</uid>
-  <version_id>627e4cc0-cc17-4794-9e45-20991f7bea21</version_id>
-  <version_modified>20200709T203651Z</version_modified>
+  <version_id>866f639e-fab9-4cfc-a484-74e21d680f4c</version_id>
+  <version_modified>20200715T232324Z</version_modified>
   <xml_checksum>15BF4E57</xml_checksum>
   <class_name>QOIReport</class_name>
   <display_name>QOI Report</display_name>
@@ -144,7 +144,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F67F4259</checksum>
+      <checksum>35BD71FB</checksum>
     </file>
   </files>
 </measure>

--- a/resources/measures/HPXMLtoOpenStudio/measure.xml
+++ b/resources/measures/HPXMLtoOpenStudio/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>hpxml_translator</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>cd25e782-05fe-4b72-aa12-b3568ed45c5e</version_id>
-  <version_modified>20200707T193058Z</version_modified>
+  <version_id>a1d38c23-e334-43e4-add7-5fdb0ef97ac3</version_id>
+  <version_modified>20200715T232326Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLTranslator</class_name>
   <display_name>HPXML Translator</display_name>
@@ -119,192 +119,6 @@
       <checksum>63C6A1E2</checksum>
     </file>
     <file>
-      <filename>HotWaterBathSchedule_1bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>2756B8A4</checksum>
-    </file>
-    <file>
-      <filename>HotWaterBathSchedule_2bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>DD7631E9</checksum>
-    </file>
-    <file>
-      <filename>HotWaterBathSchedule_3bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>CA94B43E</checksum>
-    </file>
-    <file>
-      <filename>HotWaterBathSchedule_4bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5A74968C</checksum>
-    </file>
-    <file>
-      <filename>HotWaterBathSchedule_5bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>61E873CD</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesDryerExhaustSchedule_1bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>85CDD535</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesDryerExhaustSchedule_2bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1D475929</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesDryerExhaustSchedule_3bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A0F57E5A</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesDryerExhaustSchedule_4bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A893C107</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesDryerExhaustSchedule_5bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>CDC5BFE0</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesWasherSchedule_1bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>78DFDC72</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesWasherSchedule_2bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3BAFB696</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesWasherSchedule_3bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>9289E6F2</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesWasherSchedule_4bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>268D812A</checksum>
-    </file>
-    <file>
-      <filename>HotWaterClothesWasherSchedule_5bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>5109687D</checksum>
-    </file>
-    <file>
-      <filename>HotWaterDishwasherSchedule_1bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>736F23BC</checksum>
-    </file>
-    <file>
-      <filename>HotWaterDishwasherSchedule_2bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>ADCCC080</checksum>
-    </file>
-    <file>
-      <filename>HotWaterDishwasherSchedule_3bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>54BA8BB0</checksum>
-    </file>
-    <file>
-      <filename>HotWaterDishwasherSchedule_4bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F34BF3A8</checksum>
-    </file>
-    <file>
-      <filename>HotWaterDishwasherSchedule_5bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>DAF9D44B</checksum>
-    </file>
-    <file>
-      <filename>HotWaterMinuteDrawProfilesMaxFlows.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>0E1048A3</checksum>
-    </file>
-    <file>
-      <filename>HotWaterShowerSchedule_1bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>9222E591</checksum>
-    </file>
-    <file>
-      <filename>HotWaterShowerSchedule_2bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4A282B1D</checksum>
-    </file>
-    <file>
-      <filename>HotWaterShowerSchedule_3bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>57187E02</checksum>
-    </file>
-    <file>
-      <filename>HotWaterShowerSchedule_4bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>63D51C5E</checksum>
-    </file>
-    <file>
-      <filename>HotWaterShowerSchedule_5bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>248E17B8</checksum>
-    </file>
-    <file>
-      <filename>HotWaterSinkSchedule_1bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>162386DA</checksum>
-    </file>
-    <file>
-      <filename>HotWaterSinkSchedule_2bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>ADC2C5DD</checksum>
-    </file>
-    <file>
-      <filename>HotWaterSinkSchedule_3bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>6828ECEE</checksum>
-    </file>
-    <file>
-      <filename>HotWaterSinkSchedule_4bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E6D39D36</checksum>
-    </file>
-    <file>
-      <filename>HotWaterSinkSchedule_5bed.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>35E27F20</checksum>
-    </file>
-    <file>
       <filename>pv.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -370,24 +184,6 @@
       <checksum>5D6A5C8D</checksum>
     </file>
     <file>
-      <filename>airflow.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>303BBC7F</checksum>
-    </file>
-    <file>
-      <filename>lighting.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E071B750</checksum>
-    </file>
-    <file>
-      <filename>location.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>BB6453D7</checksum>
-    </file>
-    <file>
       <filename>simulation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -418,58 +214,16 @@
       <checksum>2E6F6E14</checksum>
     </file>
     <file>
-      <filename>hvac_sizing.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>63542680</checksum>
-    </file>
-    <file>
       <filename>unit_conversions.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>0CEE8771</checksum>
     </file>
     <file>
-      <filename>hvac.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>609FB599</checksum>
-    </file>
-    <file>
-      <filename>schedules.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>B6002004</checksum>
-    </file>
-    <file>
-      <filename>constants.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>4847BCB0</checksum>
-    </file>
-    <file>
-      <filename>misc_loads.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>D6E66863</checksum>
-    </file>
-    <file>
-      <filename>geometry.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>790E6D63</checksum>
-    </file>
-    <file>
       <filename>waterheater.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>F0B6E4F4</checksum>
-    </file>
-    <file>
-      <filename>appliances.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>3F459318</checksum>
     </file>
     <file>
       <filename>util.rb</filename>
@@ -482,6 +236,66 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>0CAEB223</checksum>
+    </file>
+    <file>
+      <filename>airflow.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9A4CC023</checksum>
+    </file>
+    <file>
+      <filename>lighting.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0F00FAC3</checksum>
+    </file>
+    <file>
+      <filename>location.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>378ED94C</checksum>
+    </file>
+    <file>
+      <filename>hvac_sizing.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>BBE602FD</checksum>
+    </file>
+    <file>
+      <filename>hvac.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>40527648</checksum>
+    </file>
+    <file>
+      <filename>schedules.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>BFF49E78</checksum>
+    </file>
+    <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>0D6A1BC2</checksum>
+    </file>
+    <file>
+      <filename>misc_loads.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>58CC8BB8</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>25359C27</checksum>
+    </file>
+    <file>
+      <filename>appliances.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>7A2A038D</checksum>
     </file>
   </files>
 </measure>

--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1922,6 +1922,39 @@ class SchedulesFile
     update(col_name: col_name)
   end
 
+  def set_outage(col_name:,
+                 outage_start_date:,
+                 outage_start_hour:,
+                 outage_length:)
+
+    min_per_step = 1
+    if @model.getSimulationControl.timestep.is_initialized
+      min_per_step = 60 / @model.getSimulationControl.timestep.get.numberOfTimestepsPerHour
+    end
+
+    year_description = @model.getYearDescription
+    num_hrs_in_year = Constants.NumHoursInYear(year_description.isLeapYear)
+    schedule_length = @schedules[col_name].length
+    min_per_item = 60.0 / (schedule_length / num_hrs_in_year)
+    sec_per_step = min_per_step * 60.0
+    sim_year = year_description.calendarYear.get
+
+    start_month = outage_start_date.split[0]
+    start_day = outage_start_date.split[1].to_i
+    outage_start_date = Time.new(sim_year, OpenStudio::monthOfYear(start_month).value, start_day, outage_start_hour)
+    outage_end_date = outage_start_date + outage_length * 3600.0
+
+    ts = Time.new(sim_year, "Jan", 1)
+    @schedules[col_name].each_with_index do |step, i|
+      if outage_start_date <= ts && ts <= outage_end_date # in the outage period
+        @schedules[col_name][i] = 0.0
+      end
+      ts += sec_per_step
+    end
+
+    update(col_name: col_name)
+  end
+
   def import(col_name:)
     return if @schedules.keys.include? col_name
 


### PR DESCRIPTION
## Pull Request Description

From the PowerOutage measure, add code to modify the schedule values in `generated_files/schedules.csv` before simulation time.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).