### PR TITLE
Addresses #476, appliance design levels fluctuate between runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features
 
 Fixes
 - Based on RECS 2015, separate the plug load equations for single-family detached, single-family attached, and multifamily buildings ([#471](https://github.com/NREL/OpenStudio-BuildStock/pull/471))
+- Fix for pseudo-random number generator that was generating non-deterministic occupancy schedules ([#477](https://github.com/NREL/OpenStudio-BuildStock/pull/477))
 
 ## ResStock v2.3.0
 ###### June 24, 2020 - [Diff](https://github.com/NREL/OpenStudio-BuildStock/compare/v2.2.4...v2.3.0)

--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1417,7 +1417,7 @@ class ScheduleGenerator
       @duration_row[appliance_name] = (prng.rand * duration_vals.size).to_i
     end
     power = consumption_vals[@consumption_row[appliance_name]]
-    sample = prng.rand(0..duration_vals.length-1)
+    sample = prng.rand(0..(duration_vals.length - 1))
     duration = duration_vals[@duration_row[appliance_name]][sample]
     return [duration, power]
   end

--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1417,7 +1417,7 @@ class ScheduleGenerator
       @duration_row[appliance_name] = (prng.rand * duration_vals.size).to_i
     end
     power = consumption_vals[@consumption_row[appliance_name]]
-    sample = prng.rand(0..(duration_vals[@duration_rows[appliance_name]].length - 1))
+    sample = prng.rand(0..(duration_vals[@duration_row[appliance_name]].length - 1))
     duration = duration_vals[@duration_row[appliance_name]][sample]
     return [duration, power]
   end

--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1282,7 +1282,7 @@ class ScheduleGenerator
     end
 
     # Fill in cooking power schedule
-    # States are: 'sleeping','shower','laundry','cooking', 'dishwashing', 'absent', 'nothingAtHome'
+    # States are: 'sleeping', 'shower', 'laundry', 'cooking', 'dishwashing', 'absent', 'nothingAtHome'
     cooking_power_sch = [0] * mins_in_year
     step = 0
     last_state = 0
@@ -1417,7 +1417,8 @@ class ScheduleGenerator
       @duration_row[appliance_name] = (prng.rand * duration_vals.size).to_i
     end
     power = consumption_vals[@consumption_row[appliance_name]]
-    duration = duration_vals[@duration_row[appliance_name]].sample
+    sample = prng.rand(0..duration_vals.length-1)
+    duration = duration_vals[@duration_row[appliance_name]][sample]
     return [duration, power]
   end
 

--- a/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/schedules.rb
@@ -1417,7 +1417,7 @@ class ScheduleGenerator
       @duration_row[appliance_name] = (prng.rand * duration_vals.size).to_i
     end
     power = consumption_vals[@consumption_row[appliance_name]]
-    sample = prng.rand(0..(duration_vals.length - 1))
+    sample = prng.rand(0..(duration_vals[@duration_rows[appliance_name]].length - 1))
     duration = duration_vals[@duration_row[appliance_name]][sample]
     return [duration, power]
   end


### PR DESCRIPTION
Addresses #476.

## Pull Request Description

Fixes an issue with sampling an integer without using the pseudo-random number generator seed.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).