### PR TITLE
Addresses #481, update codecov dependency version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,19 +16,19 @@ jobs:
       - run:
           name: Update all measures
           command: |
-            bundle exec rake update_measures
+            rake update_measures
       - run: 
           name: Regenerate test osms
           command: |
-            bundle exec rake test:regenerate_osms
+            rake test:regenerate_osms
       - run: 
           name: Run all unit tests
           command: |
-            bundle exec rake test:unit_tests
+            rake test:unit_tests
       - run:
           name: Run all regression tests
           command: |
-            bundle exec rake test:regression_tests
+            rake test:regression_tests
       - store_artifacts:
             path: workflows/results
             destination: results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,19 +16,19 @@ jobs:
       - run:
           name: Update all measures
           command: |
-            rake update_measures
+            bundle exec rake update_measures
       - run: 
           name: Regenerate test osms
           command: |
-            rake test:regenerate_osms
+            bundle exec rake test:regenerate_osms
       - run: 
           name: Run all unit tests
           command: |
-            rake test:unit_tests
+            bundle exec rake test:unit_tests
       - run:
           name: Run all regression tests
           command: |
-            rake test:regression_tests
+            bundle exec rake test:regression_tests
       - store_artifacts:
             path: workflows/results
             destination: results

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rake'
+gem 'rake', '~> 11.2.2'
 gem 'colored', '~> 1.2'
 gem 'git', require: false
 
@@ -9,10 +9,10 @@ group :test do
   gem 'rubocop', '~> 0.60.0'
   gem 'rubocop-checkstyle_formatter', '~> 0.4.0'
   gem 'ci_reporter_minitest', '~> 1.0.0'
-  gem 'simplecov'
-  gem 'codecov'
+  gem 'simplecov', '~> 0.17.1'
+  gem 'simplecov-html', '~> 0.10.0'
   gem 'minitest-reporters'
-  gem 'minitest-ci'
+  gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
 end
 
 gem 'json', '~> 1.8'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'ci_reporter_minitest', '~> 1.0.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'simplecov-html', '~> 0.10.0'
-  gem 'codecov', '0.1.17'
+  gem 'codecov'
   gem 'minitest-reporters'
   gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem 'ci_reporter_minitest', '~> 1.0.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'simplecov-html', '~> 0.10.0'
+  gem 'codecov', '0.2.1'
   gem 'minitest-reporters'
   gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rake', '~> 11.2.2'
+gem 'rake'
 gem 'colored', '~> 1.2'
 gem 'git', require: false
 gem 'json', '~> 1.8'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,9 @@ group :test do
   gem 'ci_reporter_minitest', '~> 1.0.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'simplecov-html', '~> 0.10.0'
-  gem 'codecov', :git => 'https://github.com/codecov/codecov-ruby.git', :tag => 'v0.1.20'
+  git 'https://github.com/codecov/codecov-ruby.git', :tag => 'v0.1.17' do
+    gem 'codecov'
+  end
   gem 'minitest-reporters'
   gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
   gem 'ci_reporter_minitest', '~> 1.0.0'
   gem 'simplecov', '~> 0.17.1'
   gem 'simplecov-html', '~> 0.10.0'
-  gem 'codecov', '0.2.1'
+  gem 'codecov', :git => 'https://github.com/codecov/codecov-ruby.git', :tag => 'v0.1.20'
   gem 'minitest-reporters'
   gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,5 @@ gem 'rubocop-checkstyle_formatter', '~> 0.4.0'
 gem 'ci_reporter_minitest', '~> 1.0.0'
 gem 'simplecov', '~> 0.17.1'
 gem 'simplecov-html', '~> 0.10.0'
-gem 'codecov', :git => 'https://github.com/codecov/codecov-ruby.git', :tag => 'v0.1.17'
 gem 'minitest-reporters'
 gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection

--- a/Gemfile
+++ b/Gemfile
@@ -3,21 +3,6 @@ source 'http://rubygems.org'
 gem 'rake', '~> 11.2.2'
 gem 'colored', '~> 1.2'
 gem 'git', require: false
-
-group :test do
-  gem 'minitest', '~> 5.9'
-  gem 'rubocop', '~> 0.60.0'
-  gem 'rubocop-checkstyle_formatter', '~> 0.4.0'
-  gem 'ci_reporter_minitest', '~> 1.0.0'
-  gem 'simplecov', '~> 0.17.1'
-  gem 'simplecov-html', '~> 0.10.0'
-  git 'https://github.com/codecov/codecov-ruby.git', :tag => 'v0.1.17' do
-    gem 'codecov'
-  end
-  gem 'minitest-reporters'
-  gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
-end
-
 gem 'json', '~> 1.8'
 gem 'ffi', '~> 1.9.18'
 gem 'openstudio-standards', '0.2.9'
@@ -26,3 +11,13 @@ gem 'geocoder', '~> 1.4.4'
 gem 'highline', '~> 2.0.3'
 gem 'launchy', '~> 2.4.3'
 gem 'public_suffix', '3.1.1'
+
+gem 'minitest', '~> 5.9'
+gem 'rubocop', '~> 0.60.0'
+gem 'rubocop-checkstyle_formatter', '~> 0.4.0'
+gem 'ci_reporter_minitest', '~> 1.0.0'
+gem 'simplecov', '~> 0.17.1'
+gem 'simplecov-html', '~> 0.10.0'
+gem 'codecov', :git => 'https://github.com/codecov/codecov-ruby.git', :tag => 'v0.1.17'
+gem 'minitest-reporters'
+gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rake', '~> 11.2.2'
+gem 'rake'
 gem 'colored', '~> 1.2'
 gem 'git', require: false
 
@@ -9,18 +9,14 @@ group :test do
   gem 'rubocop', '~> 0.60.0'
   gem 'rubocop-checkstyle_formatter', '~> 0.4.0'
   gem 'ci_reporter_minitest', '~> 1.0.0'
-  gem 'simplecov', '~> 0.17.1'
-  gem 'simplecov-html', '~> 0.10.0'
+  gem 'simplecov'
   gem 'codecov'
   gem 'minitest-reporters'
-  gem 'minitest-ci', :git => 'https://github.com/circleci/minitest-ci.git' # For CircleCI Automatic test metadata collection
+  gem 'minitest-ci'
 end
 
-# Specify the JSON dependency so that rubocop and other gem do not try to install it
 gem 'json', '~> 1.8'
-
 gem 'ffi', '~> 1.9.18'
-
 gem 'openstudio-standards', '0.2.9'
 gem 'aes', '~> 0.5.0'
 gem 'geocoder', '~> 1.4.4'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ OpenStudio-BuildStock
 [![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/NREL/OpenStudio-BuildStock?include_prereleases)](https://github.com/NREL/OpenStudio-BuildStock/releases)
 [![CircleCI](https://circleci.com/gh/NREL/OpenStudio-BuildStock.svg?style=shield)](https://circleci.com/gh/NREL/OpenStudio-BuildStock)
 [![Documentation Status](https://readthedocs.org/projects/resstock/badge/?version=latest)](https://resstock.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/NREL/OpenStudio-BuildStock/branch/master/graph/badge.svg)](https://codecov.io/gh/NREL/OpenStudio-BuildStock)
 
 <img src="https://user-images.githubusercontent.com/1276021/85608250-1ff46b80-b612-11ea-903e-4ced367e5940.jpg" width="400">
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,20 +1,30 @@
-require 'simplecov'
 
-# save to CircleCI's artifacts directory if we're on CircleCI
-if ENV["CI"]
-  if ENV['CIRCLE_ARTIFACTS']
-    dir = File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
-    SimpleCov.coverage_dir(dir)
-  end
-else # local
-  SimpleCov.coverage_dir("coverage")
+called_from_cli = true
+begin
+  OpenStudio.getOpenStudioCLI
+rescue
+  called_from_cli = false
 end
-SimpleCov.start
 
-require 'minitest/autorun'
-require 'minitest/reporters'
+if not called_from_cli # cli can't load codecov gem
+  require 'simplecov'
 
-Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new # spec-like progress
+  # save to CircleCI's artifacts directory if we're on CircleCI
+  if ENV['CI']
+    if ENV['CIRCLE_ARTIFACTS']
+      dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')
+      SimpleCov.coverage_dir(dir)
+    end
+  else
+    SimpleCov.coverage_dir("coverage")
+  end
+  SimpleCov.start
+
+  require 'minitest/autorun'
+  require 'minitest/reporters'
+
+  Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new # spec-like progress
+end
 
 # Helper methods below for unit tests
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -7,6 +7,7 @@ end
 
 if not called_from_cli # cli can't load codecov gem
   require 'simplecov'
+  require 'codecov'
 
   # save to CircleCI's artifacts directory if we're on CircleCI
   if ENV['CI']
@@ -14,6 +15,7 @@ if not called_from_cli # cli can't load codecov gem
       dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')
       SimpleCov.coverage_dir(dir)
     end
+    SimpleCov.formatter = SimpleCov::Formatter::Codecov
   else
     SimpleCov.coverage_dir("coverage")
   end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,5 +1,4 @@
 require 'simplecov'
-require 'codecov'
 
 # save to CircleCI's artifacts directory if we're on CircleCI
 if ENV["CI"]
@@ -7,7 +6,6 @@ if ENV["CI"]
     dir = File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
     SimpleCov.coverage_dir(dir)
   end
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
 else # local
   SimpleCov.coverage_dir("coverage")
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,7 +6,7 @@ rescue
 end
 
 if not called_from_cli # cli can't load codecov gem
-  Bundler.setup
+  require 'bundler/setup'
   require 'simplecov'
   require 'codecov'
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,7 +6,7 @@ rescue
 end
 
 if not called_from_cli # cli can't load codecov gem
-  require 'bundler/setup'
+  # require 'bundler/setup'
   require 'simplecov'
   require 'codecov'
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,6 +6,7 @@ rescue
 end
 
 if not called_from_cli # cli can't load codecov gem
+  Bundler.setup
   require 'simplecov'
   require 'codecov'
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,4 +1,3 @@
-
 called_from_cli = true
 begin
   OpenStudio.getOpenStudioCLI

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,7 +6,7 @@ rescue
 end
 
 if not called_from_cli # cli can't load codecov gem
-  require 'bundler/setup'
+  # require 'bundler/setup'
   require 'simplecov'
   require 'codecov'
 
@@ -18,7 +18,7 @@ if not called_from_cli # cli can't load codecov gem
     end
     SimpleCov.formatter = SimpleCov::Formatter::Codecov
   else
-    SimpleCov.coverage_dir("coverage")
+    SimpleCov.coverage_dir('coverage')
   end
   SimpleCov.start
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,7 +6,7 @@ rescue
 end
 
 if not called_from_cli # cli can't load codecov gem
-  # require 'bundler/setup'
+  require 'bundler/setup'
   require 'simplecov'
   require 'codecov'
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -5,10 +5,8 @@ rescue
   called_from_cli = false
 end
 
-if not called_from_cli # cli can't load codecov gem
-  # require 'bundler/setup'
+if not called_from_cli
   require 'simplecov'
-  require 'codecov'
 
   # save to CircleCI's artifacts directory if we're on CircleCI
   if ENV['CI']
@@ -16,7 +14,6 @@ if not called_from_cli # cli can't load codecov gem
       dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')
       SimpleCov.coverage_dir(dir)
     end
-    SimpleCov.formatter = SimpleCov::Formatter::Codecov
   else
     SimpleCov.coverage_dir('coverage')
   end


### PR DESCRIPTION
Closes #481.

## Pull Request Description

Appears that codecov is no longer supported by ruby <2.4. So this PR removes codecov completely.

This will come back when we move to ResStock-HPXML which uses ruby 2.5.

## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [ ] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [ ] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [ ] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).