### PR TITLE
Revert zone temperature capacitance multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Features
 - Report the annual peak use and timing using the quantities of interest measure ([#458](https://github.com/NREL/OpenStudio-BuildStock/pull/458))
 - Major change to most occupant-related schedules. Occupant activities are now generated on-the-fly and saved to .csv files used by Schedule:File objects. Schedules are generated using time-inhomogenous Markov chains derived from American Time Use Survey data, supplemented with sampling duration and power level from NEEA RBSA data, as well as DHW draw duration and flow rate data from Aquacraft/AWWA data. ([#348](https://github.com/NREL/OpenStudio-BuildStock/pull/348))
-- Increase the zone temperature capacitance multiplier from 1.0 to 3.6 according to this [journal article](https://doi.org/10.1016/j.enbuild.2018.11.005) ([#472](https://github.com/NREL/OpenStudio-BuildStock/pull/472))
 - Update the dependencies for heating and cooling setpoint tsvs (Setpoint, Has Offset, Offset Magnitude, and Offset Period) to IECC climate zone ([#468](https://github.com/NREL/OpenStudio-BuildStock/pull/468))
 - Allow heating fuel to be defined by Public Use Microdata Area (PUMA) rather than State ([#474](https://github.com/NREL/OpenStudio-BuildStock/pull/474))
 - Distinguish between vacant and occupied dwelling units using PUMS data ([#473](https://github.com/NREL/OpenStudio-BuildStock/pull/473)).

--- a/resources/measures/HPXMLtoOpenStudio/resources/simulation.rb
+++ b/resources/measures/HPXMLtoOpenStudio/resources/simulation.rb
@@ -18,7 +18,6 @@ class Simulation
 
     zonecap = model.getZoneCapacitanceMultiplierResearchSpecial
     zonecap.setHumidityCapacityMultiplier(15)
-    zonecap.setTemperatureCapacityMultiplier(3.6)
 
     if not min_system_timestep_mins.nil?
       convlim = model.getConvergenceLimits


### PR DESCRIPTION
## Pull Request Description

This pull request reverts #472. The increase of the zone temperature capacitance is non-physical and should be either taken care of in thermal mass objects (i.e. furniture, or partition walls) or through air mixing (introducing multiple thermal zones and specifying the amount of mixing).

The measures are not updated or regenerated, because looks like the the `test/osm_files` already has the **Temperature Capacity Multiplier** removed. Example here: https://github.com/NREL/OpenStudio-BuildStock/blob/4073073f6f1e1e0cde681bfb8c25e35259b41d93/test/osm_files/Denver.osm#L31-L33


## Checklist

Not all may apply:

- [ ] Unit tests have been added or updated
- [ ] All rake tasks have been run, and pass
- [x] Documentation has been modified appropriately
- [ ] Any new options are added to `project_testing`
- [ ] `project_testing` runs without any failures
- [ ] No unexpected regression test changes
- [ ] All tests are passing (green) on circleci
- [x] The [changelog](https://github.com/NREL/OpenStudio-BuildStock/blob/master/CHANGELOG.md) has been updated appropriately
- [x] This branch is up-to-date with master

For more information on how to perform these checklist items, see the documentation's [Advanced Tutorial](https://resstock.readthedocs.io/en/latest/advanced_tutorial/index.html).